### PR TITLE
refactor: rename ScriptOracle to Script

### DIFF
--- a/dist/cjs/ottochain/index.js
+++ b/dist/cjs/ottochain/index.js
@@ -30,7 +30,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.MetagraphClient = exports.extractOnChainState = exports.getOracleInvocations = exports.getEventReceipts = exports.getLogsForFiber = exports.getLatestOnChainState = exports.getSnapshotOnChainState = exports.decodeOnChainState = exports.proto = void 0;
+exports.MetagraphClient = exports.extractOnChainState = exports.getScriptInvocations = exports.getEventReceipts = exports.getLogsForFiber = exports.getLatestOnChainState = exports.getSnapshotOnChainState = exports.decodeOnChainState = exports.proto = void 0;
 // Re-export generated protobuf types
 exports.proto = __importStar(require("../generated/index.js"));
 var snapshot_js_1 = require("./snapshot.js");
@@ -39,7 +39,7 @@ Object.defineProperty(exports, "getSnapshotOnChainState", { enumerable: true, ge
 Object.defineProperty(exports, "getLatestOnChainState", { enumerable: true, get: function () { return snapshot_js_1.getLatestOnChainState; } });
 Object.defineProperty(exports, "getLogsForFiber", { enumerable: true, get: function () { return snapshot_js_1.getLogsForFiber; } });
 Object.defineProperty(exports, "getEventReceipts", { enumerable: true, get: function () { return snapshot_js_1.getEventReceipts; } });
-Object.defineProperty(exports, "getOracleInvocations", { enumerable: true, get: function () { return snapshot_js_1.getOracleInvocations; } });
+Object.defineProperty(exports, "getScriptInvocations", { enumerable: true, get: function () { return snapshot_js_1.getScriptInvocations; } });
 Object.defineProperty(exports, "extractOnChainState", { enumerable: true, get: function () { return snapshot_js_1.extractOnChainState; } });
 var metagraph_client_js_1 = require("./metagraph-client.js");
 Object.defineProperty(exports, "MetagraphClient", { enumerable: true, get: function () { return metagraph_client_js_1.MetagraphClient; } });

--- a/dist/cjs/ottochain/metagraph-client.js
+++ b/dist/cjs/ottochain/metagraph-client.js
@@ -89,16 +89,16 @@ class MetagraphClient {
     /**
      * Get all script oracles, optionally filtered by status.
      */
-    async getOracles(status) {
+    async getScripts(status) {
         const query = status ? `?status=${status}` : '';
         return this.ml0.get(`/data-application/v1/oracles${query}`);
     }
     /**
      * Get a single script oracle by fiber ID.
      */
-    async getOracle(oracleId) {
+    async getScript(scriptId) {
         try {
-            return await this.ml0.get(`/data-application/v1/oracles/${oracleId}`);
+            return await this.ml0.get(`/data-application/v1/oracles/${scriptId}`);
         }
         catch (error) {
             if (error instanceof types_js_1.NetworkError && error.statusCode === 404) {
@@ -110,8 +110,8 @@ class MetagraphClient {
     /**
      * Get oracle invocations from the current ordinal's logs.
      */
-    async getOracleInvocations(oracleId) {
-        return this.ml0.get(`/data-application/v1/oracles/${oracleId}/invocations`);
+    async getScriptInvocations(scriptId) {
+        return this.ml0.get(`/data-application/v1/oracles/${scriptId}/invocations`);
     }
     // -------------------------------------------------------------------------
     // Framework snapshot endpoints (ML0 /snapshots/*)

--- a/dist/cjs/ottochain/snapshot.js
+++ b/dist/cjs/ottochain/snapshot.js
@@ -11,7 +11,7 @@
  * @packageDocumentation
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getOracleInvocations = exports.getEventReceipts = exports.getLogsForFiber = exports.extractOnChainState = exports.getLatestOnChainState = exports.getSnapshotOnChainState = exports.decodeOnChainState = void 0;
+exports.getScriptInvocations = exports.getEventReceipts = exports.getLogsForFiber = exports.extractOnChainState = exports.getLatestOnChainState = exports.getSnapshotOnChainState = exports.decodeOnChainState = void 0;
 const client_js_1 = require("../metakit/network/client.js");
 /**
  * Decode on-chain state from binary (JsonBinaryCodec format).
@@ -103,8 +103,8 @@ exports.getEventReceipts = getEventReceipts;
  * @param fiberId - Fiber UUID to filter by
  * @returns Array of OracleInvocation entries
  */
-function getOracleInvocations(onChain, fiberId) {
+function getScriptInvocations(onChain, fiberId) {
     return getLogsForFiber(onChain, fiberId)
         .filter((entry) => 'method' in entry && 'result' in entry);
 }
-exports.getOracleInvocations = getOracleInvocations;
+exports.getScriptInvocations = getScriptInvocations;

--- a/dist/esm/ottochain/index.js
+++ b/dist/esm/ottochain/index.js
@@ -7,5 +7,5 @@
  */
 // Re-export generated protobuf types
 export * as proto from '../generated/index.js';
-export { decodeOnChainState, getSnapshotOnChainState, getLatestOnChainState, getLogsForFiber, getEventReceipts, getOracleInvocations, extractOnChainState, } from './snapshot.js';
+export { decodeOnChainState, getSnapshotOnChainState, getLatestOnChainState, getLogsForFiber, getEventReceipts, getScriptInvocations, extractOnChainState, } from './snapshot.js';
 export { MetagraphClient } from './metagraph-client.js';

--- a/dist/esm/ottochain/metagraph-client.js
+++ b/dist/esm/ottochain/metagraph-client.js
@@ -86,16 +86,16 @@ export class MetagraphClient {
     /**
      * Get all script oracles, optionally filtered by status.
      */
-    async getOracles(status) {
+    async getScripts(status) {
         const query = status ? `?status=${status}` : '';
         return this.ml0.get(`/data-application/v1/oracles${query}`);
     }
     /**
      * Get a single script oracle by fiber ID.
      */
-    async getOracle(oracleId) {
+    async getScript(scriptId) {
         try {
-            return await this.ml0.get(`/data-application/v1/oracles/${oracleId}`);
+            return await this.ml0.get(`/data-application/v1/oracles/${scriptId}`);
         }
         catch (error) {
             if (error instanceof NetworkError && error.statusCode === 404) {
@@ -107,8 +107,8 @@ export class MetagraphClient {
     /**
      * Get oracle invocations from the current ordinal's logs.
      */
-    async getOracleInvocations(oracleId) {
-        return this.ml0.get(`/data-application/v1/oracles/${oracleId}/invocations`);
+    async getScriptInvocations(scriptId) {
+        return this.ml0.get(`/data-application/v1/oracles/${scriptId}/invocations`);
     }
     // -------------------------------------------------------------------------
     // Framework snapshot endpoints (ML0 /snapshots/*)

--- a/dist/esm/ottochain/snapshot.js
+++ b/dist/esm/ottochain/snapshot.js
@@ -94,7 +94,7 @@ export function getEventReceipts(onChain, fiberId) {
  * @param fiberId - Fiber UUID to filter by
  * @returns Array of OracleInvocation entries
  */
-export function getOracleInvocations(onChain, fiberId) {
+export function getScriptInvocations(onChain, fiberId) {
     return getLogsForFiber(onChain, fiberId)
         .filter((entry) => 'method' in entry && 'result' in entry);
 }

--- a/dist/types/ottochain/index.d.ts
+++ b/dist/types/ottochain/index.d.ts
@@ -6,8 +6,8 @@
  * @packageDocumentation
  */
 export * as proto from '../generated/index.js';
-export type { FiberOrdinal, SnapshotOrdinal, StateId, Address, HashValue, JsonLogicValue, JsonLogicExpression, FiberStatus, AccessControlPolicy, StateMachineDefinition, EmittedEvent, EventReceipt, OracleInvocation, FiberLogEntry, StateMachineFiberRecord, ScriptOracleFiberRecord, FiberRecord, FiberCommit, OnChain, CalculatedState, CreateStateMachine, TransitionStateMachine, ArchiveStateMachine, CreateScriptOracle, InvokeScriptOracle, OttochainMessage, } from './types.js';
+export type { FiberOrdinal, SnapshotOrdinal, StateId, Address, HashValue, JsonLogicValue, JsonLogicExpression, FiberStatus, AccessControlPolicy, StateMachineDefinition, EmittedEvent, EventReceipt, OracleInvocation, FiberLogEntry, StateMachineFiberRecord, ScriptFiberRecord, FiberRecord, FiberCommit, OnChain, CalculatedState, CreateStateMachine, TransitionStateMachine, ArchiveStateMachine, CreateScript, InvokeScript, OttochainMessage, } from './types.js';
 export type { CurrencySnapshotResponse } from './snapshot.js';
-export { decodeOnChainState, getSnapshotOnChainState, getLatestOnChainState, getLogsForFiber, getEventReceipts, getOracleInvocations, extractOnChainState, } from './snapshot.js';
+export { decodeOnChainState, getSnapshotOnChainState, getLatestOnChainState, getLogsForFiber, getEventReceipts, getScriptInvocations, extractOnChainState, } from './snapshot.js';
 export type { Checkpoint, MetagraphClientConfig } from './metagraph-client.js';
 export { MetagraphClient } from './metagraph-client.js';

--- a/dist/types/ottochain/metagraph-client.d.ts
+++ b/dist/types/ottochain/metagraph-client.d.ts
@@ -8,7 +8,7 @@
  * @see modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1CustomRoutes.scala
  * @packageDocumentation
  */
-import type { OnChain, CalculatedState, StateMachineFiberRecord, ScriptOracleFiberRecord, EventReceipt, OracleInvocation, FiberStatus } from './types.js';
+import type { OnChain, CalculatedState, StateMachineFiberRecord, ScriptFiberRecord, EventReceipt, OracleInvocation, FiberStatus } from './types.js';
 /**
  * Checkpoint response from the metagraph (ordinal + calculated state).
  */
@@ -77,15 +77,15 @@ export declare class MetagraphClient {
     /**
      * Get all script oracles, optionally filtered by status.
      */
-    getOracles(status?: FiberStatus): Promise<Record<string, ScriptOracleFiberRecord>>;
+    getScripts(status?: FiberStatus): Promise<Record<string, ScriptFiberRecord>>;
     /**
      * Get a single script oracle by fiber ID.
      */
-    getOracle(oracleId: string): Promise<ScriptOracleFiberRecord | null>;
+    getScript(scriptId: string): Promise<ScriptFiberRecord | null>;
     /**
      * Get oracle invocations from the current ordinal's logs.
      */
-    getOracleInvocations(oracleId: string): Promise<OracleInvocation[]>;
+    getScriptInvocations(scriptId: string): Promise<OracleInvocation[]>;
     /**
      * Get the latest snapshot and decode its on-chain state.
      */

--- a/dist/types/ottochain/snapshot.d.ts
+++ b/dist/types/ottochain/snapshot.d.ts
@@ -83,4 +83,4 @@ export declare function getEventReceipts(onChain: OnChain, fiberId: string): Eve
  * @param fiberId - Fiber UUID to filter by
  * @returns Array of OracleInvocation entries
  */
-export declare function getOracleInvocations(onChain: OnChain, fiberId: string): OracleInvocation[];
+export declare function getScriptInvocations(onChain: OnChain, fiberId: string): OracleInvocation[];

--- a/dist/types/ottochain/types.d.ts
+++ b/dist/types/ottochain/types.d.ts
@@ -114,7 +114,7 @@ export interface EventReceipt {
 }
 /**
  * Log entry for a script oracle invocation.
- * Emitted as a FiberLogEntry after each InvokeScriptOracle.
+ * Emitted as a FiberLogEntry after each InvokeScript.
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberLogEntry.scala
  */
@@ -158,7 +158,7 @@ export interface StateMachineFiberRecord {
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
  */
-export interface ScriptOracleFiberRecord {
+export interface ScriptFiberRecord {
     fiberId: string;
     creationOrdinal: SnapshotOrdinal;
     latestUpdateOrdinal: SnapshotOrdinal;
@@ -174,7 +174,7 @@ export interface ScriptOracleFiberRecord {
 /**
  * Union type for all fiber records.
  */
-export type FiberRecord = StateMachineFiberRecord | ScriptOracleFiberRecord;
+export type FiberRecord = StateMachineFiberRecord | ScriptFiberRecord;
 /**
  * Commit hash for a single fiber in the on-chain state.
  *
@@ -204,7 +204,7 @@ export interface OnChain {
  */
 export interface CalculatedState {
     stateMachines: Record<string, StateMachineFiberRecord>;
-    scriptOracles: Record<string, ScriptOracleFiberRecord>;
+    scripts: Record<string, ScriptFiberRecord>;
 }
 /**
  * Create a new state machine fiber.
@@ -242,7 +242,7 @@ export interface ArchiveStateMachine {
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
  */
-export interface CreateScriptOracle {
+export interface CreateScript {
     fiberId: string;
     scriptProgram: JsonLogicExpression;
     initialState?: JsonLogicValue;
@@ -253,7 +253,7 @@ export interface CreateScriptOracle {
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
  */
-export interface InvokeScriptOracle {
+export interface InvokeScript {
     fiberId: string;
     method: string;
     args: JsonLogicValue;
@@ -272,7 +272,7 @@ export type OttochainMessage = {
 } | {
     ArchiveStateMachine: ArchiveStateMachine;
 } | {
-    CreateScriptOracle: CreateScriptOracle;
+    CreateScript: CreateScript;
 } | {
-    InvokeScriptOracle: InvokeScriptOracle;
+    InvokeScript: InvokeScript;
 };

--- a/src/ottochain/index.ts
+++ b/src/ottochain/index.ts
@@ -37,7 +37,7 @@ export type {
 
   // Fiber records
   StateMachineFiberRecord,
-  ScriptOracleFiberRecord,
+  ScriptFiberRecord,
   FiberRecord,
 
   // On-chain state
@@ -51,8 +51,8 @@ export type {
   CreateStateMachine,
   TransitionStateMachine,
   ArchiveStateMachine,
-  CreateScriptOracle,
-  InvokeScriptOracle,
+  CreateScript,
+  InvokeScript,
   OttochainMessage,
 } from './types.js';
 
@@ -64,7 +64,7 @@ export {
   getLatestOnChainState,
   getLogsForFiber,
   getEventReceipts,
-  getOracleInvocations,
+  getScriptInvocations,
   extractOnChainState,
 } from './snapshot.js';
 

--- a/src/ottochain/metagraph-client.ts
+++ b/src/ottochain/metagraph-client.ts
@@ -15,7 +15,7 @@ import type {
   OnChain,
   CalculatedState,
   StateMachineFiberRecord,
-  ScriptOracleFiberRecord,
+  ScriptFiberRecord,
   EventReceipt,
   OracleInvocation,
   FiberStatus,
@@ -133,9 +133,9 @@ export class MetagraphClient {
   /**
    * Get all script oracles, optionally filtered by status.
    */
-  async getOracles(status?: FiberStatus): Promise<Record<string, ScriptOracleFiberRecord>> {
+  async getScripts(status?: FiberStatus): Promise<Record<string, ScriptFiberRecord>> {
     const query = status ? `?status=${status}` : '';
-    return this.ml0.get<Record<string, ScriptOracleFiberRecord>>(
+    return this.ml0.get<Record<string, ScriptFiberRecord>>(
       `/data-application/v1/oracles${query}`
     );
   }
@@ -143,10 +143,10 @@ export class MetagraphClient {
   /**
    * Get a single script oracle by fiber ID.
    */
-  async getOracle(oracleId: string): Promise<ScriptOracleFiberRecord | null> {
+  async getScript(scriptId: string): Promise<ScriptFiberRecord | null> {
     try {
-      return await this.ml0.get<ScriptOracleFiberRecord>(
-        `/data-application/v1/oracles/${oracleId}`
+      return await this.ml0.get<ScriptFiberRecord>(
+        `/data-application/v1/oracles/${scriptId}`
       );
     } catch (error) {
       if (error instanceof NetworkError && error.statusCode === 404) {
@@ -159,9 +159,9 @@ export class MetagraphClient {
   /**
    * Get oracle invocations from the current ordinal's logs.
    */
-  async getOracleInvocations(oracleId: string): Promise<OracleInvocation[]> {
+  async getScriptInvocations(scriptId: string): Promise<OracleInvocation[]> {
     return this.ml0.get<OracleInvocation[]>(
-      `/data-application/v1/oracles/${oracleId}/invocations`
+      `/data-application/v1/oracles/${scriptId}/invocations`
     );
   }
 

--- a/src/ottochain/snapshot.ts
+++ b/src/ottochain/snapshot.ts
@@ -126,7 +126,7 @@ export function getEventReceipts(onChain: OnChain, fiberId: string): EventReceip
  * @param fiberId - Fiber UUID to filter by
  * @returns Array of OracleInvocation entries
  */
-export function getOracleInvocations(onChain: OnChain, fiberId: string): OracleInvocation[] {
+export function getScriptInvocations(onChain: OnChain, fiberId: string): OracleInvocation[] {
   return getLogsForFiber(onChain, fiberId)
     .filter((entry): entry is OracleInvocation => 'method' in entry && 'result' in entry);
 }

--- a/src/ottochain/types.ts
+++ b/src/ottochain/types.ts
@@ -140,7 +140,7 @@ export interface EventReceipt {
 
 /**
  * Log entry for a script oracle invocation.
- * Emitted as a FiberLogEntry after each InvokeScriptOracle.
+ * Emitted as a FiberLogEntry after each InvokeScript.
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberLogEntry.scala
  */
@@ -191,7 +191,7 @@ export interface StateMachineFiberRecord {
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
  */
-export interface ScriptOracleFiberRecord {
+export interface ScriptFiberRecord {
   fiberId: string;
   creationOrdinal: SnapshotOrdinal;
   latestUpdateOrdinal: SnapshotOrdinal;
@@ -208,7 +208,7 @@ export interface ScriptOracleFiberRecord {
 /**
  * Union type for all fiber records.
  */
-export type FiberRecord = StateMachineFiberRecord | ScriptOracleFiberRecord;
+export type FiberRecord = StateMachineFiberRecord | ScriptFiberRecord;
 
 // ---------------------------------------------------------------------------
 // On-chain state
@@ -249,7 +249,7 @@ export interface OnChain {
  */
 export interface CalculatedState {
   stateMachines: Record<string, StateMachineFiberRecord>;
-  scriptOracles: Record<string, ScriptOracleFiberRecord>;
+  scripts: Record<string, ScriptFiberRecord>;
 }
 
 // ---------------------------------------------------------------------------
@@ -295,7 +295,7 @@ export interface ArchiveStateMachine {
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
  */
-export interface CreateScriptOracle {
+export interface CreateScript {
   fiberId: string;
   scriptProgram: JsonLogicExpression;
   initialState?: JsonLogicValue;
@@ -307,7 +307,7 @@ export interface CreateScriptOracle {
  *
  * @see modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
  */
-export interface InvokeScriptOracle {
+export interface InvokeScript {
   fiberId: string;
   method: string;
   args: JsonLogicValue;
@@ -324,5 +324,5 @@ export type OttochainMessage =
   | { CreateStateMachine: CreateStateMachine }
   | { TransitionStateMachine: TransitionStateMachine }
   | { ArchiveStateMachine: ArchiveStateMachine }
-  | { CreateScriptOracle: CreateScriptOracle }
-  | { InvokeScriptOracle: InvokeScriptOracle };
+  | { CreateScript: CreateScript }
+  | { InvokeScript: InvokeScript };


### PR DESCRIPTION
Aligns TypeScript SDK with Scala codebase rename (PR #7 in main repo).

Changes:
- ScriptOracleFiberRecord → ScriptFiberRecord
- CreateScriptOracle → CreateScript
- InvokeScriptOracle → InvokeScript
- scriptOracles → scripts
- getOracles → getScripts
- getOracle → getScript
- oracleId → scriptId