### PR TITLE
fix: export markets and oracles proto types

### DIFF
--- a/dist/cjs/generated/index.js
+++ b/dist/cjs/generated/index.js
@@ -32,3 +32,7 @@ __exportStar(require("./ottochain/apps/identity/v1/agent_pb.js"), exports);
 __exportStar(require("./ottochain/apps/identity/v1/attestation_pb.js"), exports);
 // App: Contracts
 __exportStar(require("./ottochain/apps/contracts/v1/contract_pb.js"), exports);
+// App: Markets
+__exportStar(require("./ottochain/apps/markets/v1/market_pb.js"), exports);
+// App: Oracles
+__exportStar(require("./ottochain/apps/oracles/v1/oracle_pb.js"), exports);

--- a/dist/esm/generated/index.js
+++ b/dist/esm/generated/index.js
@@ -16,3 +16,7 @@ export * from './ottochain/apps/identity/v1/agent_pb.js';
 export * from './ottochain/apps/identity/v1/attestation_pb.js';
 // App: Contracts
 export * from './ottochain/apps/contracts/v1/contract_pb.js';
+// App: Markets
+export * from './ottochain/apps/markets/v1/market_pb.js';
+// App: Oracles
+export * from './ottochain/apps/oracles/v1/oracle_pb.js';

--- a/dist/types/generated/index.d.ts
+++ b/dist/types/generated/index.d.ts
@@ -13,3 +13,5 @@ export * from './ottochain/v1/records_pb.js';
 export * from './ottochain/apps/identity/v1/agent_pb.js';
 export * from './ottochain/apps/identity/v1/attestation_pb.js';
 export * from './ottochain/apps/contracts/v1/contract_pb.js';
+export * from './ottochain/apps/markets/v1/market_pb.js';
+export * from './ottochain/apps/oracles/v1/oracle_pb.js';

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -19,3 +19,9 @@ export * from './ottochain/apps/identity/v1/attestation_pb.js';
 
 // App: Contracts
 export * from './ottochain/apps/contracts/v1/contract_pb.js';
+
+// App: Markets
+export * from './ottochain/apps/markets/v1/market_pb.js';
+
+// App: Oracles
+export * from './ottochain/apps/oracles/v1/oracle_pb.js';


### PR DESCRIPTION
Add missing exports to `src/generated/index.ts`:
- `ottochain/apps/markets/v1/market_pb.js`
- `ottochain/apps/oracles/v1/oracle_pb.js`

These types are needed by the bridge to use proto-generated models instead of hardcoding definitions.

**Exports added:**
```typescript
// From @ottochain/sdk
import { 
  Market, MarketState, MarketType,
  Commitment, Resolution,
  CreateMarketRequest, CommitToMarketRequest,
  Oracle, OracleState, 
  // etc.
} from '@ottochain/sdk';
```

Part of the effort to have bridge use SDK proto types as the single source of truth.