### PR TITLE
feat: symmetric app exports for markets and oracles

### DIFF
--- a/dist/cjs/apps/markets/index.js
+++ b/dist/cjs/apps/markets/index.js
@@ -11,8 +11,12 @@
  *   MarketState,
  *   MarketType,
  *   calculatePayout,
- *   DEFAULT_MARKET_CONFIG
+ *   DEFAULT_MARKET_CONFIG,
+ *   getMarketDefinition
  * } from '@ottochain/sdk/apps/markets';
+ *
+ * // Get the universal market state machine definition
+ * const marketDef = getMarketDefinition();
  *
  * // Calculate payout for a winning prediction
  * const payout = calculatePayout({
@@ -38,9 +42,36 @@ var __createBinding = (this && this.__createBinding) || (Object.create ? (functi
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-// Note: Once proto files are generated, uncomment these exports:
-// export * from '../../generated/ottochain/apps/markets/v1/market_pb.js';
-// export * from '../../generated/ottochain/apps/markets/v1/commitment_pb.js';
+exports.getMarketDefinition = exports.MARKET_DEFINITIONS = void 0;
+// Re-export generated protobuf types
+__exportStar(require("../../generated/ottochain/apps/markets/v1/market_pb.js"), exports);
 // Export convenience types, constants, and helpers
 __exportStar(require("./types.js"), exports);
+// ---------------------------------------------------------------------------
+// State Machine JSON Definitions
+// ---------------------------------------------------------------------------
+const market_universal_json_1 = __importDefault(require("./state-machines/market-universal.json"));
+/**
+ * Market state machine definitions mapped by type.
+ */
+exports.MARKET_DEFINITIONS = {
+    Universal: market_universal_json_1.default,
+};
+/**
+ * Get the market state machine definition.
+ *
+ * @param type - Definition type (default: 'Universal')
+ * @returns The state machine definition JSON
+ */
+function getMarketDefinition(type = 'Universal') {
+    const def = exports.MARKET_DEFINITIONS[type];
+    if (!def) {
+        throw new Error(`Unknown market definition type: ${type}`);
+    }
+    return def;
+}
+exports.getMarketDefinition = getMarketDefinition;

--- a/dist/cjs/apps/markets/state-machines/market-universal.json
+++ b/dist/cjs/apps/markets/state-machines/market-universal.json
@@ -1,0 +1,280 @@
+{
+    "metadata": {
+        "name": "Market",
+        "description": "Universal market state machine: predictions, auctions, crowdfunding, group buys",
+        "version": "1.0.0"
+    },
+    "states": {
+        "PROPOSED": { "id": { "value": "PROPOSED" }, "isFinal": false },
+        "OPEN": { "id": { "value": "OPEN" }, "isFinal": false },
+        "CLOSED": { "id": { "value": "CLOSED" }, "isFinal": false },
+        "RESOLVING": { "id": { "value": "RESOLVING" }, "isFinal": false },
+        "SETTLED": { "id": { "value": "SETTLED" }, "isFinal": true },
+        "REFUNDED": { "id": { "value": "REFUNDED" }, "isFinal": true },
+        "CANCELLED": { "id": { "value": "CANCELLED" }, "isFinal": true }
+    },
+    "initialState": { "value": "PROPOSED" },
+    "transitions": [
+        {
+            "_comment": "Creator opens the market for participation",
+            "from": { "value": "PROPOSED" },
+            "to": { "value": "OPEN" },
+            "eventName": "open",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "OPEN", "openedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Creator cancels before opening",
+            "from": { "value": "PROPOSED" },
+            "to": { "value": "CANCELLED" },
+            "eventName": "cancel",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "CANCELLED", "cancelledAt": { "var": "$timestamp" }, "reason": { "var": "event.reason" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Participant commits resources (stake/bid/pledge/order)",
+            "from": { "value": "OPEN" },
+            "to": { "value": "OPEN" },
+            "eventName": "commit",
+            "guard": {
+                "and": [
+                    { ">": [{ "var": "event.amount" }, 0] },
+                    { "or": [
+                            { "!": { "var": "state.deadline" } },
+                            { "<=": [{ "var": "$timestamp" }, { "var": "state.deadline" }] }
+                        ] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "commitments": {
+                            "setKey": [
+                                { "var": "state.commitments" },
+                                { "var": "event.agent" },
+                                {
+                                    "merge": [
+                                        { "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }, { "amount": 0, "data": {} }] },
+                                        {
+                                            "amount": { "+": [
+                                                    { "getKey": [{ "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }, { "amount": 0 }] }, "amount", 0] },
+                                                    { "var": "event.amount" }
+                                                ] },
+                                            "data": { "var": "event.data" },
+                                            "lastCommitAt": { "var": "$timestamp" }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "totalCommitted": { "+": [{ "var": "state.totalCommitted" }, { "var": "event.amount" }] }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Close market for new commitments (manual or deadline)",
+            "from": { "value": "OPEN" },
+            "to": { "value": "CLOSED" },
+            "eventName": "close",
+            "guard": {
+                "or": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+                    { "and": [
+                            { "var": "state.deadline" },
+                            { ">=": [{ "var": "$timestamp" }, { "var": "state.deadline" }] }
+                        ] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "CLOSED", "closedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Submit resolution (oracle/auctioneer/system)",
+            "from": { "value": "CLOSED" },
+            "to": { "value": "RESOLVING" },
+            "eventName": "submit_resolution",
+            "guard": {
+                "or": [
+                    { "in": [{ "var": "event.agent" }, { "var": "state.oracles" }] },
+                    { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "RESOLVING",
+                        "resolutions": {
+                            "cat": [
+                                { "var": "state.resolutions" },
+                                [{
+                                        "oracle": { "var": "event.agent" },
+                                        "outcome": { "var": "event.outcome" },
+                                        "proof": { "var": "event.proof" },
+                                        "submittedAt": { "var": "$timestamp" }
+                                    }]
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Additional oracle votes during resolution",
+            "from": { "value": "RESOLVING" },
+            "to": { "value": "RESOLVING" },
+            "eventName": "submit_resolution",
+            "guard": {
+                "and": [
+                    { "in": [{ "var": "event.agent" }, { "var": "state.oracles" }] },
+                    { "!": { "in": [{ "var": "event.agent" }, { "map": [{ "var": "state.resolutions" }, { "var": "oracle" }] }] } }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "resolutions": {
+                            "cat": [
+                                { "var": "state.resolutions" },
+                                [{
+                                        "oracle": { "var": "event.agent" },
+                                        "outcome": { "var": "event.outcome" },
+                                        "proof": { "var": "event.proof" },
+                                        "submittedAt": { "var": "$timestamp" }
+                                    }]
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Finalize when quorum reached or threshold met",
+            "from": { "value": "RESOLVING" },
+            "to": { "value": "SETTLED" },
+            "eventName": "finalize",
+            "guard": {
+                "or": [
+                    { ">=": [{ "size": { "var": "state.resolutions" } }, { "var": "state.quorum" }] },
+                    { "===": [{ "var": "state.marketType" }, "crowdfund"] },
+                    { "===": [{ "var": "state.marketType" }, "group_buy"] },
+                    { "===": [{ "var": "state.marketType" }, "auction"] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "SETTLED",
+                        "settledAt": { "var": "$timestamp" },
+                        "finalOutcome": { "var": "event.outcome" },
+                        "settlement": { "var": "event.settlement" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Refund if threshold not met",
+            "from": { "value": "CLOSED" },
+            "to": { "value": "REFUNDED" },
+            "eventName": "refund",
+            "guard": {
+                "and": [
+                    { "var": "state.threshold" },
+                    { "<": [{ "var": "state.totalCommitted" }, { "var": "state.threshold" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "REFUNDED", "refundedAt": { "var": "$timestamp" }, "reason": "threshold_not_met" }
+                ]
+            }
+        },
+        {
+            "_comment": "Refund from resolving if disputed/failed",
+            "from": { "value": "RESOLVING" },
+            "to": { "value": "REFUNDED" },
+            "eventName": "refund",
+            "guard": {
+                "or": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+                    { ">=": [{ "size": { "filter": [{ "var": "state.resolutions" }, { "===": [{ "var": "outcome" }, "INVALID"] }] } }, { "var": "state.quorum" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "REFUNDED", "refundedAt": { "var": "$timestamp" }, "reason": { "var": "event.reason" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Claim winnings/rewards after settlement",
+            "from": { "value": "SETTLED" },
+            "to": { "value": "SETTLED" },
+            "eventName": "claim",
+            "guard": {
+                "and": [
+                    { "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }] },
+                    { "!": { "getKey": [{ "var": "state.claims" }, { "var": "event.agent" }] } }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "claims": {
+                            "setKey": [
+                                { "var": "state.claims" },
+                                { "var": "event.agent" },
+                                { "claimedAt": { "var": "$timestamp" }, "amount": { "var": "event.amount" } }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "initialDataTemplate": {
+        "_comment": "Template for creating new markets",
+        "schema": "Market",
+        "marketType": "prediction | auction | crowdfund | group_buy",
+        "creator": "<address>",
+        "title": "",
+        "description": "",
+        "terms": {
+            "_comment": "Type-specific configuration",
+            "prediction": { "question": "", "outcomes": ["YES", "NO"], "feePercent": 2 },
+            "auction": { "item": "", "reservePrice": 0, "buyNowPrice": null },
+            "crowdfund": { "goal": 0, "rewards": [], "allOrNothing": true },
+            "group_buy": { "product": "", "unitPrice": 0, "bulkPrice": 0, "minUnits": 0 }
+        },
+        "deadline": null,
+        "threshold": null,
+        "oracles": [],
+        "quorum": 1,
+        "commitments": {},
+        "totalCommitted": 0,
+        "resolutions": [],
+        "claims": {},
+        "status": "PROPOSED"
+    }
+}

--- a/dist/cjs/apps/markets/types.js
+++ b/dist/cjs/apps/markets/types.js
@@ -4,49 +4,14 @@
  *
  * Constants, types, and utilities for the Markets application on OttoChain.
  *
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (MarketType, MarketState, Market, Commitment, Resolution) are
+ * exported from proto-generated types in index.ts.
  *
  * @packageDocumentation
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isMarketType = exports.isMarketState = exports.calculateGroupBuyDiscount = exports.calculateCrowdfundProgress = exports.validateCommitment = exports.calculateRefund = exports.calculatePayout = exports.calculateFees = exports.calculateNetCommitment = exports.isTerminalMarketState = exports.MARKET_TRANSITIONS = exports.MARKET_TYPE_CONFIGS = exports.DEFAULT_MARKET_CONFIG = exports.CommitmentSide = exports.MarketType = exports.MarketState = void 0;
-// ---------------------------------------------------------------------------
-// Enums (will be replaced by proto-generated versions)
-// ---------------------------------------------------------------------------
-/**
- * Market lifecycle states
- */
-var MarketState;
-(function (MarketState) {
-    MarketState[MarketState["UNSPECIFIED"] = 0] = "UNSPECIFIED";
-    /** Market is open for commitments */
-    MarketState[MarketState["OPEN"] = 1] = "OPEN";
-    /** Commitment period has ended, awaiting resolution */
-    MarketState[MarketState["CLOSED"] = 2] = "CLOSED";
-    /** Oracle has resolved the outcome */
-    MarketState[MarketState["RESOLVED"] = 3] = "RESOLVED";
-    /** Payouts distributed to winners */
-    MarketState[MarketState["SETTLED"] = 4] = "SETTLED";
-    /** Market cancelled, refunds issued */
-    MarketState[MarketState["CANCELLED"] = 5] = "CANCELLED";
-    /** Market is disputed */
-    MarketState[MarketState["DISPUTED"] = 6] = "DISPUTED";
-})(MarketState || (exports.MarketState = MarketState = {}));
-/**
- * Types of markets supported
- */
-var MarketType;
-(function (MarketType) {
-    MarketType[MarketType["UNSPECIFIED"] = 0] = "UNSPECIFIED";
-    /** Binary or multi-outcome prediction market */
-    MarketType[MarketType["PREDICTION"] = 1] = "PREDICTION";
-    /** Ascending/descending price auction */
-    MarketType[MarketType["AUCTION"] = 2] = "AUCTION";
-    /** All-or-nothing crowdfunding */
-    MarketType[MarketType["CROWDFUND"] = 3] = "CROWDFUND";
-    /** Group buying with volume discounts */
-    MarketType[MarketType["GROUP_BUY"] = 4] = "GROUP_BUY";
-})(MarketType || (exports.MarketType = MarketType = {}));
+exports.isMarketType = exports.isMarketState = exports.calculateGroupBuyDiscount = exports.calculateCrowdfundProgress = exports.validateCommitment = exports.calculateRefund = exports.calculatePayout = exports.calculateFees = exports.calculateNetCommitment = exports.isTerminalMarketState = exports.MARKET_TRANSITIONS = exports.MARKET_TYPE_CONFIGS = exports.DEFAULT_MARKET_CONFIG = exports.CommitmentSide = void 0;
+const market_pb_js_1 = require("../../generated/ottochain/apps/markets/v1/market_pb.js");
 /**
  * Commitment direction (for prediction markets)
  */
@@ -73,24 +38,24 @@ exports.DEFAULT_MARKET_CONFIG = {
  * Type-specific market configurations
  */
 exports.MARKET_TYPE_CONFIGS = {
-    [MarketType.UNSPECIFIED]: {},
-    [MarketType.PREDICTION]: {
+    [market_pb_js_1.MarketType.UNSPECIFIED]: {},
+    [market_pb_js_1.MarketType.PREDICTION]: {
         platformFeePercent: 0.02,
         oracleFeePercent: 0.02,
     },
-    [MarketType.AUCTION]: {
+    [market_pb_js_1.MarketType.AUCTION]: {
         platformFeePercent: 0.025,
         creatorFeePercent: 0,
         oracleFeePercent: 0,
         minQuorum: 1n,
     },
-    [MarketType.CROWDFUND]: {
+    [market_pb_js_1.MarketType.CROWDFUND]: {
         platformFeePercent: 0.03,
         creatorFeePercent: 0,
         oracleFeePercent: 0,
         disputeWindowEpochs: 0,
     },
-    [MarketType.GROUP_BUY]: {
+    [market_pb_js_1.MarketType.GROUP_BUY]: {
         platformFeePercent: 0.015,
         creatorFeePercent: 0.01,
         oracleFeePercent: 0,
@@ -100,24 +65,26 @@ exports.MARKET_TYPE_CONFIGS = {
 // State Machine Transitions
 // ---------------------------------------------------------------------------
 /**
- * Valid transitions for each market state
+ * Valid transitions for each market state (aligned with proto MarketState enum)
  */
 exports.MARKET_TRANSITIONS = {
-    [MarketState.UNSPECIFIED]: [],
-    [MarketState.OPEN]: ['close', 'cancel'],
-    [MarketState.CLOSED]: ['resolve', 'dispute', 'cancel'],
-    [MarketState.RESOLVED]: ['settle', 'dispute'],
-    [MarketState.SETTLED]: [], // Terminal state
-    [MarketState.CANCELLED]: [], // Terminal state
-    [MarketState.DISPUTED]: ['resolve_dispute', 'cancel'],
+    [market_pb_js_1.MarketState.UNSPECIFIED]: [],
+    [market_pb_js_1.MarketState.PROPOSED]: ['open', 'cancel'],
+    [market_pb_js_1.MarketState.OPEN]: ['close', 'cancel', 'commit'],
+    [market_pb_js_1.MarketState.CLOSED]: ['submit_resolution', 'refund'],
+    [market_pb_js_1.MarketState.RESOLVING]: ['submit_resolution', 'finalize', 'refund'],
+    [market_pb_js_1.MarketState.SETTLED]: ['claim'], // Terminal (only claims allowed)
+    [market_pb_js_1.MarketState.REFUNDED]: [], // Terminal state
+    [market_pb_js_1.MarketState.CANCELLED]: [], // Terminal state
 };
 /**
  * Check if a market state is terminal
  */
 function isTerminalMarketState(state) {
     return [
-        MarketState.SETTLED,
-        MarketState.CANCELLED,
+        market_pb_js_1.MarketState.SETTLED,
+        market_pb_js_1.MarketState.REFUNDED,
+        market_pb_js_1.MarketState.CANCELLED,
     ].includes(state);
 }
 exports.isTerminalMarketState = isTerminalMarketState;
@@ -144,7 +111,7 @@ exports.calculateNetCommitment = calculateNetCommitment;
  * @param marketType - Type of market for type-specific fees
  * @returns Fee breakdown object
  */
-function calculateFees(amount, marketType = MarketType.PREDICTION) {
+function calculateFees(amount, marketType = market_pb_js_1.MarketType.PREDICTION) {
     const typeConfig = { ...exports.DEFAULT_MARKET_CONFIG, ...exports.MARKET_TYPE_CONFIGS[marketType] };
     const platform = (amount * BigInt(Math.floor(typeConfig.platformFeePercent * 10000))) / 10000n;
     const creator = (amount * BigInt(Math.floor(typeConfig.creatorFeePercent * 10000))) / 10000n;
@@ -166,7 +133,7 @@ exports.calculateFees = calculateFees;
  * @param marketType - Type of market for fee calculation
  * @returns Payout amount
  */
-function calculatePayout(shares, marketType = MarketType.PREDICTION) {
+function calculatePayout(shares, marketType = market_pb_js_1.MarketType.PREDICTION) {
     if (shares.winningPool === 0n)
         return 0n;
     const fees = calculateFees(shares.losingPool, marketType);
@@ -194,7 +161,7 @@ exports.calculateRefund = calculateRefund;
  */
 function validateCommitment(amount, marketState, config = {}) {
     const minCommitment = config.minCommitment ?? exports.DEFAULT_MARKET_CONFIG.minCommitment;
-    if (marketState !== MarketState.OPEN) {
+    if (marketState !== market_pb_js_1.MarketState.OPEN) {
         return { valid: false, reason: 'Market is not open for commitments' };
     }
     if (amount < minCommitment) {
@@ -240,13 +207,13 @@ exports.calculateGroupBuyDiscount = calculateGroupBuyDiscount;
  * Check if a value is a valid MarketState
  */
 function isMarketState(value) {
-    return typeof value === 'number' && value in MarketState;
+    return typeof value === 'number' && value in market_pb_js_1.MarketState;
 }
 exports.isMarketState = isMarketState;
 /**
  * Check if a value is a valid MarketType
  */
 function isMarketType(value) {
-    return typeof value === 'number' && value in MarketType;
+    return typeof value === 'number' && value in market_pb_js_1.MarketType;
 }
 exports.isMarketType = isMarketType;

--- a/dist/cjs/apps/oracles/index.js
+++ b/dist/cjs/apps/oracles/index.js
@@ -12,8 +12,12 @@
  *   SlashingReason,
  *   calculateReputation,
  *   calculateSlashAmount,
- *   DEFAULT_ORACLE_CONFIG
+ *   DEFAULT_ORACLE_CONFIG,
+ *   getOracleDefinition
  * } from '@ottochain/sdk/apps/oracles';
+ *
+ * // Get the oracle state machine definition
+ * const oracleDef = getOracleDefinition();
  *
  * // Calculate new reputation after successful resolution
  * const newRep = calculateReputation(50, REPUTATION_DELTAS.successfulResolution);
@@ -38,9 +42,36 @@ var __createBinding = (this && this.__createBinding) || (Object.create ? (functi
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-// Note: Once proto files are generated, uncomment these exports:
-// export * from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
-// export * from '../../generated/ottochain/apps/oracles/v1/resolution_pb.js';
+exports.getOracleDefinition = exports.ORACLE_DEFINITIONS = void 0;
+// Re-export generated protobuf types
+__exportStar(require("../../generated/ottochain/apps/oracles/v1/oracle_pb.js"), exports);
 // Export convenience types, constants, and helpers
 __exportStar(require("./types.js"), exports);
+// ---------------------------------------------------------------------------
+// State Machine JSON Definitions
+// ---------------------------------------------------------------------------
+const oracle_json_1 = __importDefault(require("./state-machines/oracle.json"));
+/**
+ * Oracle state machine definitions mapped by type.
+ */
+exports.ORACLE_DEFINITIONS = {
+    Oracle: oracle_json_1.default,
+};
+/**
+ * Get the oracle state machine definition.
+ *
+ * @param type - Definition type (default: 'Oracle')
+ * @returns The state machine definition JSON
+ */
+function getOracleDefinition(type = 'Oracle') {
+    const def = exports.ORACLE_DEFINITIONS[type];
+    if (!def) {
+        throw new Error(`Unknown oracle definition type: ${type}`);
+    }
+    return def;
+}
+exports.getOracleDefinition = getOracleDefinition;

--- a/dist/cjs/apps/oracles/state-machines/oracle.json
+++ b/dist/cjs/apps/oracles/state-machines/oracle.json
@@ -1,0 +1,211 @@
+{
+    "metadata": {
+        "name": "Oracle",
+        "description": "Oracle registration, reputation, and slashing state machine",
+        "version": "1.0.0"
+    },
+    "states": {
+        "UNREGISTERED": { "id": { "value": "UNREGISTERED" }, "isFinal": false },
+        "REGISTERED": { "id": { "value": "REGISTERED" }, "isFinal": false },
+        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+        "SLASHED": { "id": { "value": "SLASHED" }, "isFinal": false },
+        "WITHDRAWN": { "id": { "value": "WITHDRAWN" }, "isFinal": true }
+    },
+    "initialState": { "value": "UNREGISTERED" },
+    "transitions": [
+        {
+            "_comment": "Register as oracle with initial stake",
+            "from": { "value": "UNREGISTERED" },
+            "to": { "value": "REGISTERED" },
+            "eventName": "register",
+            "guard": {
+                ">=": [{ "var": "event.stake" }, { "var": "state.minStake" }]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "REGISTERED",
+                        "address": { "var": "event.agent" },
+                        "stake": { "var": "event.stake" },
+                        "registeredAt": { "var": "$timestamp" },
+                        "reputation": { "accuracy": 100, "totalResolutions": 0, "disputesWon": 0, "disputesLost": 0 },
+                        "domains": { "var": "event.domains" },
+                        "slashingHistory": []
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Activate oracle after verification period",
+            "from": { "value": "REGISTERED" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "activate",
+            "guard": {
+                "or": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+                    { "var": "event.adminOverride" }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "ACTIVE", "activatedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Add more stake",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "add_stake",
+            "guard": {
+                "and": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+                    { ">": [{ "var": "event.amount" }, 0] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "stake": { "+": [{ "var": "state.stake" }, { "var": "event.amount" }] },
+                        "lastStakeAt": { "var": "$timestamp" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Record successful resolution (called by market settlement)",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "record_resolution",
+            "guard": { "var": "event.marketId" },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "reputation": {
+                            "merge": [
+                                { "var": "state.reputation" },
+                                {
+                                    "totalResolutions": { "+": [{ "var": "state.reputation.totalResolutions" }, 1] },
+                                    "accuracy": {
+                                        "if": [
+                                            { "var": "event.correct" },
+                                            { "var": "state.reputation.accuracy" },
+                                            { "-": [{ "var": "state.reputation.accuracy" }, 5] }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "lastResolutionAt": { "var": "$timestamp" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Slash oracle for misbehavior",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "SLASHED" },
+            "eventName": "slash",
+            "guard": {
+                "and": [
+                    { "var": "event.reason" },
+                    { ">": [{ "var": "event.amount" }, 0] },
+                    { "<=": [{ "var": "event.amount" }, { "var": "state.stake" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "SLASHED",
+                        "stake": { "-": [{ "var": "state.stake" }, { "var": "event.amount" }] },
+                        "slashingHistory": {
+                            "cat": [
+                                { "var": "state.slashingHistory" },
+                                [{
+                                        "reason": { "var": "event.reason" },
+                                        "amount": { "var": "event.amount" },
+                                        "marketId": { "var": "event.marketId" },
+                                        "slashedAt": { "var": "$timestamp" }
+                                    }]
+                            ]
+                        },
+                        "slashedAt": { "var": "$timestamp" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Reactivate after slash cooldown",
+            "from": { "value": "SLASHED" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "reactivate",
+            "guard": {
+                "and": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+                    { ">=": [{ "var": "state.stake" }, { "var": "state.minStake" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "ACTIVE", "reactivatedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Withdraw from oracle role",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "WITHDRAWN" },
+            "eventName": "withdraw",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "WITHDRAWN",
+                        "withdrawnAt": { "var": "$timestamp" },
+                        "finalStake": { "var": "state.stake" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Withdraw after slash (may have reduced stake)",
+            "from": { "value": "SLASHED" },
+            "to": { "value": "WITHDRAWN" },
+            "eventName": "withdraw",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "WITHDRAWN",
+                        "withdrawnAt": { "var": "$timestamp" },
+                        "finalStake": { "var": "state.stake" }
+                    }
+                ]
+            }
+        }
+    ],
+    "initialDataTemplate": {
+        "_comment": "Template for creating new oracle registrations",
+        "schema": "Oracle",
+        "address": "<address>",
+        "stake": 0,
+        "minStake": 100,
+        "reputation": {
+            "accuracy": 100,
+            "totalResolutions": 0,
+            "disputesWon": 0,
+            "disputesLost": 0
+        },
+        "domains": [],
+        "slashingHistory": [],
+        "status": "UNREGISTERED"
+    }
+}

--- a/dist/cjs/apps/oracles/types.js
+++ b/dist/cjs/apps/oracles/types.js
@@ -5,36 +5,14 @@
  * Constants, types, and utilities for the Oracle system on OttoChain.
  * Oracles provide truth resolution for markets and disputes.
  *
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (OracleState, Oracle, etc.) are exported from proto-generated
+ * types in index.ts.
  *
  * @packageDocumentation
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isResolutionType = exports.isSlashingReason = exports.isOracleState = exports.calculateOracleReward = exports.calculateSelectionScore = exports.calculateStakeAfterSlash = exports.calculateSlashAmount = exports.SLASHING_CONDITIONS = exports.qualifiesForHighValue = exports.calculateWeightedReputation = exports.calculateReputation = exports.REPUTATION_DELTAS = exports.canAcceptAssignment = exports.isTerminalOracleState = exports.ORACLE_TRANSITIONS = exports.SLASHING_PERCENTAGES = exports.DEFAULT_ORACLE_CONFIG = exports.SlashingReason = exports.ResolutionType = exports.OracleState = void 0;
-// ---------------------------------------------------------------------------
-// Enums (will be replaced by proto-generated versions)
-// ---------------------------------------------------------------------------
-/**
- * Oracle lifecycle states
- */
-var OracleState;
-(function (OracleState) {
-    OracleState[OracleState["UNSPECIFIED"] = 0] = "UNSPECIFIED";
-    /** Oracle has registered but not yet staked */
-    OracleState[OracleState["REGISTERED"] = 1] = "REGISTERED";
-    /** Oracle is staked and available for assignments */
-    OracleState[OracleState["ACTIVE"] = 2] = "ACTIVE";
-    /** Oracle is currently assigned to resolve a market */
-    OracleState[OracleState["ASSIGNED"] = 3] = "ASSIGNED";
-    /** Oracle has submitted a resolution, in challenge period */
-    OracleState[OracleState["SUBMITTED"] = 4] = "SUBMITTED";
-    /** Oracle is under review due to dispute */
-    OracleState[OracleState["CHALLENGED"] = 5] = "CHALLENGED";
-    /** Oracle is suspended due to slashing */
-    OracleState[OracleState["SUSPENDED"] = 6] = "SUSPENDED";
-    /** Oracle has withdrawn stake and exited */
-    OracleState[OracleState["WITHDRAWN"] = 7] = "WITHDRAWN";
-})(OracleState || (exports.OracleState = OracleState = {}));
+exports.isResolutionType = exports.isSlashingReason = exports.isOracleState = exports.calculateOracleReward = exports.calculateSelectionScore = exports.calculateStakeAfterSlash = exports.calculateSlashAmount = exports.SLASHING_CONDITIONS = exports.qualifiesForHighValue = exports.calculateWeightedReputation = exports.calculateReputation = exports.REPUTATION_DELTAS = exports.canAcceptAssignment = exports.isTerminalOracleState = exports.ORACLE_TRANSITIONS = exports.SLASHING_PERCENTAGES = exports.DEFAULT_ORACLE_CONFIG = exports.SlashingReason = exports.ResolutionType = void 0;
+const oracle_pb_js_1 = require("../../generated/ottochain/apps/oracles/v1/oracle_pb.js");
 /**
  * Types of oracle resolutions
  */
@@ -95,30 +73,28 @@ exports.SLASHING_PERCENTAGES = {
 // State Machine Transitions
 // ---------------------------------------------------------------------------
 /**
- * Valid transitions for each oracle state
+ * Valid transitions for each oracle state (aligned with proto OracleState enum)
  */
 exports.ORACLE_TRANSITIONS = {
-    [OracleState.UNSPECIFIED]: [],
-    [OracleState.REGISTERED]: ['stake', 'withdraw'],
-    [OracleState.ACTIVE]: ['assign', 'unstake'],
-    [OracleState.ASSIGNED]: ['submit', 'timeout'],
-    [OracleState.SUBMITTED]: ['finalize', 'challenge'],
-    [OracleState.CHALLENGED]: ['uphold', 'overturn'],
-    [OracleState.SUSPENDED]: ['begin_probation', 'permanent_ban'],
-    [OracleState.WITHDRAWN]: [], // Terminal state
+    [oracle_pb_js_1.OracleState.UNSPECIFIED]: [],
+    [oracle_pb_js_1.OracleState.UNREGISTERED]: ['register'],
+    [oracle_pb_js_1.OracleState.REGISTERED]: ['activate', 'withdraw'],
+    [oracle_pb_js_1.OracleState.ACTIVE]: ['add_stake', 'record_resolution', 'slash', 'withdraw'],
+    [oracle_pb_js_1.OracleState.SLASHED]: ['reactivate', 'withdraw'],
+    [oracle_pb_js_1.OracleState.WITHDRAWN]: [], // Terminal state
 };
 /**
  * Check if an oracle state is terminal
  */
 function isTerminalOracleState(state) {
-    return state === OracleState.WITHDRAWN;
+    return state === oracle_pb_js_1.OracleState.WITHDRAWN;
 }
 exports.isTerminalOracleState = isTerminalOracleState;
 /**
  * Check if an oracle can accept new assignments
  */
 function canAcceptAssignment(state) {
-    return state === OracleState.ACTIVE;
+    return state === oracle_pb_js_1.OracleState.ACTIVE;
 }
 exports.canAcceptAssignment = canAcceptAssignment;
 // ---------------------------------------------------------------------------
@@ -287,7 +263,7 @@ exports.calculateOracleReward = calculateOracleReward;
  * Check if a value is a valid OracleState
  */
 function isOracleState(value) {
-    return typeof value === 'number' && value in OracleState;
+    return typeof value === 'number' && value in oracle_pb_js_1.OracleState;
 }
 exports.isOracleState = isOracleState;
 /**

--- a/dist/esm/apps/markets/index.js
+++ b/dist/esm/apps/markets/index.js
@@ -10,8 +10,12 @@
  *   MarketState,
  *   MarketType,
  *   calculatePayout,
- *   DEFAULT_MARKET_CONFIG
+ *   DEFAULT_MARKET_CONFIG,
+ *   getMarketDefinition
  * } from '@ottochain/sdk/apps/markets';
+ *
+ * // Get the universal market state machine definition
+ * const marketDef = getMarketDefinition();
  *
  * // Calculate payout for a winning prediction
  * const payout = calculatePayout({
@@ -23,8 +27,30 @@
  *
  * @packageDocumentation
  */
-// Note: Once proto files are generated, uncomment these exports:
-// export * from '../../generated/ottochain/apps/markets/v1/market_pb.js';
-// export * from '../../generated/ottochain/apps/markets/v1/commitment_pb.js';
+// Re-export generated protobuf types
+export * from '../../generated/ottochain/apps/markets/v1/market_pb.js';
 // Export convenience types, constants, and helpers
 export * from './types.js';
+// ---------------------------------------------------------------------------
+// State Machine JSON Definitions
+// ---------------------------------------------------------------------------
+import marketUniversalDef from './state-machines/market-universal.json';
+/**
+ * Market state machine definitions mapped by type.
+ */
+export const MARKET_DEFINITIONS = {
+    Universal: marketUniversalDef,
+};
+/**
+ * Get the market state machine definition.
+ *
+ * @param type - Definition type (default: 'Universal')
+ * @returns The state machine definition JSON
+ */
+export function getMarketDefinition(type = 'Universal') {
+    const def = MARKET_DEFINITIONS[type];
+    if (!def) {
+        throw new Error(`Unknown market definition type: ${type}`);
+    }
+    return def;
+}

--- a/dist/esm/apps/markets/state-machines/market-universal.json
+++ b/dist/esm/apps/markets/state-machines/market-universal.json
@@ -1,0 +1,280 @@
+{
+    "metadata": {
+        "name": "Market",
+        "description": "Universal market state machine: predictions, auctions, crowdfunding, group buys",
+        "version": "1.0.0"
+    },
+    "states": {
+        "PROPOSED": { "id": { "value": "PROPOSED" }, "isFinal": false },
+        "OPEN": { "id": { "value": "OPEN" }, "isFinal": false },
+        "CLOSED": { "id": { "value": "CLOSED" }, "isFinal": false },
+        "RESOLVING": { "id": { "value": "RESOLVING" }, "isFinal": false },
+        "SETTLED": { "id": { "value": "SETTLED" }, "isFinal": true },
+        "REFUNDED": { "id": { "value": "REFUNDED" }, "isFinal": true },
+        "CANCELLED": { "id": { "value": "CANCELLED" }, "isFinal": true }
+    },
+    "initialState": { "value": "PROPOSED" },
+    "transitions": [
+        {
+            "_comment": "Creator opens the market for participation",
+            "from": { "value": "PROPOSED" },
+            "to": { "value": "OPEN" },
+            "eventName": "open",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "OPEN", "openedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Creator cancels before opening",
+            "from": { "value": "PROPOSED" },
+            "to": { "value": "CANCELLED" },
+            "eventName": "cancel",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "CANCELLED", "cancelledAt": { "var": "$timestamp" }, "reason": { "var": "event.reason" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Participant commits resources (stake/bid/pledge/order)",
+            "from": { "value": "OPEN" },
+            "to": { "value": "OPEN" },
+            "eventName": "commit",
+            "guard": {
+                "and": [
+                    { ">": [{ "var": "event.amount" }, 0] },
+                    { "or": [
+                            { "!": { "var": "state.deadline" } },
+                            { "<=": [{ "var": "$timestamp" }, { "var": "state.deadline" }] }
+                        ] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "commitments": {
+                            "setKey": [
+                                { "var": "state.commitments" },
+                                { "var": "event.agent" },
+                                {
+                                    "merge": [
+                                        { "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }, { "amount": 0, "data": {} }] },
+                                        {
+                                            "amount": { "+": [
+                                                    { "getKey": [{ "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }, { "amount": 0 }] }, "amount", 0] },
+                                                    { "var": "event.amount" }
+                                                ] },
+                                            "data": { "var": "event.data" },
+                                            "lastCommitAt": { "var": "$timestamp" }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "totalCommitted": { "+": [{ "var": "state.totalCommitted" }, { "var": "event.amount" }] }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Close market for new commitments (manual or deadline)",
+            "from": { "value": "OPEN" },
+            "to": { "value": "CLOSED" },
+            "eventName": "close",
+            "guard": {
+                "or": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+                    { "and": [
+                            { "var": "state.deadline" },
+                            { ">=": [{ "var": "$timestamp" }, { "var": "state.deadline" }] }
+                        ] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "CLOSED", "closedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Submit resolution (oracle/auctioneer/system)",
+            "from": { "value": "CLOSED" },
+            "to": { "value": "RESOLVING" },
+            "eventName": "submit_resolution",
+            "guard": {
+                "or": [
+                    { "in": [{ "var": "event.agent" }, { "var": "state.oracles" }] },
+                    { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "RESOLVING",
+                        "resolutions": {
+                            "cat": [
+                                { "var": "state.resolutions" },
+                                [{
+                                        "oracle": { "var": "event.agent" },
+                                        "outcome": { "var": "event.outcome" },
+                                        "proof": { "var": "event.proof" },
+                                        "submittedAt": { "var": "$timestamp" }
+                                    }]
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Additional oracle votes during resolution",
+            "from": { "value": "RESOLVING" },
+            "to": { "value": "RESOLVING" },
+            "eventName": "submit_resolution",
+            "guard": {
+                "and": [
+                    { "in": [{ "var": "event.agent" }, { "var": "state.oracles" }] },
+                    { "!": { "in": [{ "var": "event.agent" }, { "map": [{ "var": "state.resolutions" }, { "var": "oracle" }] }] } }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "resolutions": {
+                            "cat": [
+                                { "var": "state.resolutions" },
+                                [{
+                                        "oracle": { "var": "event.agent" },
+                                        "outcome": { "var": "event.outcome" },
+                                        "proof": { "var": "event.proof" },
+                                        "submittedAt": { "var": "$timestamp" }
+                                    }]
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Finalize when quorum reached or threshold met",
+            "from": { "value": "RESOLVING" },
+            "to": { "value": "SETTLED" },
+            "eventName": "finalize",
+            "guard": {
+                "or": [
+                    { ">=": [{ "size": { "var": "state.resolutions" } }, { "var": "state.quorum" }] },
+                    { "===": [{ "var": "state.marketType" }, "crowdfund"] },
+                    { "===": [{ "var": "state.marketType" }, "group_buy"] },
+                    { "===": [{ "var": "state.marketType" }, "auction"] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "SETTLED",
+                        "settledAt": { "var": "$timestamp" },
+                        "finalOutcome": { "var": "event.outcome" },
+                        "settlement": { "var": "event.settlement" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Refund if threshold not met",
+            "from": { "value": "CLOSED" },
+            "to": { "value": "REFUNDED" },
+            "eventName": "refund",
+            "guard": {
+                "and": [
+                    { "var": "state.threshold" },
+                    { "<": [{ "var": "state.totalCommitted" }, { "var": "state.threshold" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "REFUNDED", "refundedAt": { "var": "$timestamp" }, "reason": "threshold_not_met" }
+                ]
+            }
+        },
+        {
+            "_comment": "Refund from resolving if disputed/failed",
+            "from": { "value": "RESOLVING" },
+            "to": { "value": "REFUNDED" },
+            "eventName": "refund",
+            "guard": {
+                "or": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+                    { ">=": [{ "size": { "filter": [{ "var": "state.resolutions" }, { "===": [{ "var": "outcome" }, "INVALID"] }] } }, { "var": "state.quorum" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "REFUNDED", "refundedAt": { "var": "$timestamp" }, "reason": { "var": "event.reason" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Claim winnings/rewards after settlement",
+            "from": { "value": "SETTLED" },
+            "to": { "value": "SETTLED" },
+            "eventName": "claim",
+            "guard": {
+                "and": [
+                    { "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }] },
+                    { "!": { "getKey": [{ "var": "state.claims" }, { "var": "event.agent" }] } }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "claims": {
+                            "setKey": [
+                                { "var": "state.claims" },
+                                { "var": "event.agent" },
+                                { "claimedAt": { "var": "$timestamp" }, "amount": { "var": "event.amount" } }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "initialDataTemplate": {
+        "_comment": "Template for creating new markets",
+        "schema": "Market",
+        "marketType": "prediction | auction | crowdfund | group_buy",
+        "creator": "<address>",
+        "title": "",
+        "description": "",
+        "terms": {
+            "_comment": "Type-specific configuration",
+            "prediction": { "question": "", "outcomes": ["YES", "NO"], "feePercent": 2 },
+            "auction": { "item": "", "reservePrice": 0, "buyNowPrice": null },
+            "crowdfund": { "goal": 0, "rewards": [], "allOrNothing": true },
+            "group_buy": { "product": "", "unitPrice": 0, "bulkPrice": 0, "minUnits": 0 }
+        },
+        "deadline": null,
+        "threshold": null,
+        "oracles": [],
+        "quorum": 1,
+        "commitments": {},
+        "totalCommitted": 0,
+        "resolutions": [],
+        "claims": {},
+        "status": "PROPOSED"
+    }
+}

--- a/dist/esm/apps/markets/types.js
+++ b/dist/esm/apps/markets/types.js
@@ -3,47 +3,12 @@
  *
  * Constants, types, and utilities for the Markets application on OttoChain.
  *
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (MarketType, MarketState, Market, Commitment, Resolution) are
+ * exported from proto-generated types in index.ts.
  *
  * @packageDocumentation
  */
-// ---------------------------------------------------------------------------
-// Enums (will be replaced by proto-generated versions)
-// ---------------------------------------------------------------------------
-/**
- * Market lifecycle states
- */
-export var MarketState;
-(function (MarketState) {
-    MarketState[MarketState["UNSPECIFIED"] = 0] = "UNSPECIFIED";
-    /** Market is open for commitments */
-    MarketState[MarketState["OPEN"] = 1] = "OPEN";
-    /** Commitment period has ended, awaiting resolution */
-    MarketState[MarketState["CLOSED"] = 2] = "CLOSED";
-    /** Oracle has resolved the outcome */
-    MarketState[MarketState["RESOLVED"] = 3] = "RESOLVED";
-    /** Payouts distributed to winners */
-    MarketState[MarketState["SETTLED"] = 4] = "SETTLED";
-    /** Market cancelled, refunds issued */
-    MarketState[MarketState["CANCELLED"] = 5] = "CANCELLED";
-    /** Market is disputed */
-    MarketState[MarketState["DISPUTED"] = 6] = "DISPUTED";
-})(MarketState || (MarketState = {}));
-/**
- * Types of markets supported
- */
-export var MarketType;
-(function (MarketType) {
-    MarketType[MarketType["UNSPECIFIED"] = 0] = "UNSPECIFIED";
-    /** Binary or multi-outcome prediction market */
-    MarketType[MarketType["PREDICTION"] = 1] = "PREDICTION";
-    /** Ascending/descending price auction */
-    MarketType[MarketType["AUCTION"] = 2] = "AUCTION";
-    /** All-or-nothing crowdfunding */
-    MarketType[MarketType["CROWDFUND"] = 3] = "CROWDFUND";
-    /** Group buying with volume discounts */
-    MarketType[MarketType["GROUP_BUY"] = 4] = "GROUP_BUY";
-})(MarketType || (MarketType = {}));
+import { MarketType, MarketState } from '../../generated/ottochain/apps/markets/v1/market_pb.js';
 /**
  * Commitment direction (for prediction markets)
  */
@@ -97,16 +62,17 @@ export const MARKET_TYPE_CONFIGS = {
 // State Machine Transitions
 // ---------------------------------------------------------------------------
 /**
- * Valid transitions for each market state
+ * Valid transitions for each market state (aligned with proto MarketState enum)
  */
 export const MARKET_TRANSITIONS = {
     [MarketState.UNSPECIFIED]: [],
-    [MarketState.OPEN]: ['close', 'cancel'],
-    [MarketState.CLOSED]: ['resolve', 'dispute', 'cancel'],
-    [MarketState.RESOLVED]: ['settle', 'dispute'],
-    [MarketState.SETTLED]: [], // Terminal state
+    [MarketState.PROPOSED]: ['open', 'cancel'],
+    [MarketState.OPEN]: ['close', 'cancel', 'commit'],
+    [MarketState.CLOSED]: ['submit_resolution', 'refund'],
+    [MarketState.RESOLVING]: ['submit_resolution', 'finalize', 'refund'],
+    [MarketState.SETTLED]: ['claim'], // Terminal (only claims allowed)
+    [MarketState.REFUNDED]: [], // Terminal state
     [MarketState.CANCELLED]: [], // Terminal state
-    [MarketState.DISPUTED]: ['resolve_dispute', 'cancel'],
 };
 /**
  * Check if a market state is terminal
@@ -114,6 +80,7 @@ export const MARKET_TRANSITIONS = {
 export function isTerminalMarketState(state) {
     return [
         MarketState.SETTLED,
+        MarketState.REFUNDED,
         MarketState.CANCELLED,
     ].includes(state);
 }

--- a/dist/esm/apps/oracles/index.js
+++ b/dist/esm/apps/oracles/index.js
@@ -11,8 +11,12 @@
  *   SlashingReason,
  *   calculateReputation,
  *   calculateSlashAmount,
- *   DEFAULT_ORACLE_CONFIG
+ *   DEFAULT_ORACLE_CONFIG,
+ *   getOracleDefinition
  * } from '@ottochain/sdk/apps/oracles';
+ *
+ * // Get the oracle state machine definition
+ * const oracleDef = getOracleDefinition();
  *
  * // Calculate new reputation after successful resolution
  * const newRep = calculateReputation(50, REPUTATION_DELTAS.successfulResolution);
@@ -23,8 +27,30 @@
  *
  * @packageDocumentation
  */
-// Note: Once proto files are generated, uncomment these exports:
-// export * from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
-// export * from '../../generated/ottochain/apps/oracles/v1/resolution_pb.js';
+// Re-export generated protobuf types
+export * from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
 // Export convenience types, constants, and helpers
 export * from './types.js';
+// ---------------------------------------------------------------------------
+// State Machine JSON Definitions
+// ---------------------------------------------------------------------------
+import oracleDef from './state-machines/oracle.json';
+/**
+ * Oracle state machine definitions mapped by type.
+ */
+export const ORACLE_DEFINITIONS = {
+    Oracle: oracleDef,
+};
+/**
+ * Get the oracle state machine definition.
+ *
+ * @param type - Definition type (default: 'Oracle')
+ * @returns The state machine definition JSON
+ */
+export function getOracleDefinition(type = 'Oracle') {
+    const def = ORACLE_DEFINITIONS[type];
+    if (!def) {
+        throw new Error(`Unknown oracle definition type: ${type}`);
+    }
+    return def;
+}

--- a/dist/esm/apps/oracles/state-machines/oracle.json
+++ b/dist/esm/apps/oracles/state-machines/oracle.json
@@ -1,0 +1,211 @@
+{
+    "metadata": {
+        "name": "Oracle",
+        "description": "Oracle registration, reputation, and slashing state machine",
+        "version": "1.0.0"
+    },
+    "states": {
+        "UNREGISTERED": { "id": { "value": "UNREGISTERED" }, "isFinal": false },
+        "REGISTERED": { "id": { "value": "REGISTERED" }, "isFinal": false },
+        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+        "SLASHED": { "id": { "value": "SLASHED" }, "isFinal": false },
+        "WITHDRAWN": { "id": { "value": "WITHDRAWN" }, "isFinal": true }
+    },
+    "initialState": { "value": "UNREGISTERED" },
+    "transitions": [
+        {
+            "_comment": "Register as oracle with initial stake",
+            "from": { "value": "UNREGISTERED" },
+            "to": { "value": "REGISTERED" },
+            "eventName": "register",
+            "guard": {
+                ">=": [{ "var": "event.stake" }, { "var": "state.minStake" }]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "REGISTERED",
+                        "address": { "var": "event.agent" },
+                        "stake": { "var": "event.stake" },
+                        "registeredAt": { "var": "$timestamp" },
+                        "reputation": { "accuracy": 100, "totalResolutions": 0, "disputesWon": 0, "disputesLost": 0 },
+                        "domains": { "var": "event.domains" },
+                        "slashingHistory": []
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Activate oracle after verification period",
+            "from": { "value": "REGISTERED" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "activate",
+            "guard": {
+                "or": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+                    { "var": "event.adminOverride" }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "ACTIVE", "activatedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Add more stake",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "add_stake",
+            "guard": {
+                "and": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+                    { ">": [{ "var": "event.amount" }, 0] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "stake": { "+": [{ "var": "state.stake" }, { "var": "event.amount" }] },
+                        "lastStakeAt": { "var": "$timestamp" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Record successful resolution (called by market settlement)",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "record_resolution",
+            "guard": { "var": "event.marketId" },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "reputation": {
+                            "merge": [
+                                { "var": "state.reputation" },
+                                {
+                                    "totalResolutions": { "+": [{ "var": "state.reputation.totalResolutions" }, 1] },
+                                    "accuracy": {
+                                        "if": [
+                                            { "var": "event.correct" },
+                                            { "var": "state.reputation.accuracy" },
+                                            { "-": [{ "var": "state.reputation.accuracy" }, 5] }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "lastResolutionAt": { "var": "$timestamp" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Slash oracle for misbehavior",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "SLASHED" },
+            "eventName": "slash",
+            "guard": {
+                "and": [
+                    { "var": "event.reason" },
+                    { ">": [{ "var": "event.amount" }, 0] },
+                    { "<=": [{ "var": "event.amount" }, { "var": "state.stake" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "SLASHED",
+                        "stake": { "-": [{ "var": "state.stake" }, { "var": "event.amount" }] },
+                        "slashingHistory": {
+                            "cat": [
+                                { "var": "state.slashingHistory" },
+                                [{
+                                        "reason": { "var": "event.reason" },
+                                        "amount": { "var": "event.amount" },
+                                        "marketId": { "var": "event.marketId" },
+                                        "slashedAt": { "var": "$timestamp" }
+                                    }]
+                            ]
+                        },
+                        "slashedAt": { "var": "$timestamp" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Reactivate after slash cooldown",
+            "from": { "value": "SLASHED" },
+            "to": { "value": "ACTIVE" },
+            "eventName": "reactivate",
+            "guard": {
+                "and": [
+                    { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+                    { ">=": [{ "var": "state.stake" }, { "var": "state.minStake" }] }
+                ]
+            },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    { "status": "ACTIVE", "reactivatedAt": { "var": "$timestamp" } }
+                ]
+            }
+        },
+        {
+            "_comment": "Withdraw from oracle role",
+            "from": { "value": "ACTIVE" },
+            "to": { "value": "WITHDRAWN" },
+            "eventName": "withdraw",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "WITHDRAWN",
+                        "withdrawnAt": { "var": "$timestamp" },
+                        "finalStake": { "var": "state.stake" }
+                    }
+                ]
+            }
+        },
+        {
+            "_comment": "Withdraw after slash (may have reduced stake)",
+            "from": { "value": "SLASHED" },
+            "to": { "value": "WITHDRAWN" },
+            "eventName": "withdraw",
+            "guard": { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+            "effect": {
+                "merge": [
+                    { "var": "state" },
+                    {
+                        "status": "WITHDRAWN",
+                        "withdrawnAt": { "var": "$timestamp" },
+                        "finalStake": { "var": "state.stake" }
+                    }
+                ]
+            }
+        }
+    ],
+    "initialDataTemplate": {
+        "_comment": "Template for creating new oracle registrations",
+        "schema": "Oracle",
+        "address": "<address>",
+        "stake": 0,
+        "minStake": 100,
+        "reputation": {
+            "accuracy": 100,
+            "totalResolutions": 0,
+            "disputesWon": 0,
+            "disputesLost": 0
+        },
+        "domains": [],
+        "slashingHistory": [],
+        "status": "UNREGISTERED"
+    }
+}

--- a/dist/esm/apps/oracles/types.js
+++ b/dist/esm/apps/oracles/types.js
@@ -4,34 +4,12 @@
  * Constants, types, and utilities for the Oracle system on OttoChain.
  * Oracles provide truth resolution for markets and disputes.
  *
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (OracleState, Oracle, etc.) are exported from proto-generated
+ * types in index.ts.
  *
  * @packageDocumentation
  */
-// ---------------------------------------------------------------------------
-// Enums (will be replaced by proto-generated versions)
-// ---------------------------------------------------------------------------
-/**
- * Oracle lifecycle states
- */
-export var OracleState;
-(function (OracleState) {
-    OracleState[OracleState["UNSPECIFIED"] = 0] = "UNSPECIFIED";
-    /** Oracle has registered but not yet staked */
-    OracleState[OracleState["REGISTERED"] = 1] = "REGISTERED";
-    /** Oracle is staked and available for assignments */
-    OracleState[OracleState["ACTIVE"] = 2] = "ACTIVE";
-    /** Oracle is currently assigned to resolve a market */
-    OracleState[OracleState["ASSIGNED"] = 3] = "ASSIGNED";
-    /** Oracle has submitted a resolution, in challenge period */
-    OracleState[OracleState["SUBMITTED"] = 4] = "SUBMITTED";
-    /** Oracle is under review due to dispute */
-    OracleState[OracleState["CHALLENGED"] = 5] = "CHALLENGED";
-    /** Oracle is suspended due to slashing */
-    OracleState[OracleState["SUSPENDED"] = 6] = "SUSPENDED";
-    /** Oracle has withdrawn stake and exited */
-    OracleState[OracleState["WITHDRAWN"] = 7] = "WITHDRAWN";
-})(OracleState || (OracleState = {}));
+import { OracleState } from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
 /**
  * Types of oracle resolutions
  */
@@ -92,16 +70,14 @@ export const SLASHING_PERCENTAGES = {
 // State Machine Transitions
 // ---------------------------------------------------------------------------
 /**
- * Valid transitions for each oracle state
+ * Valid transitions for each oracle state (aligned with proto OracleState enum)
  */
 export const ORACLE_TRANSITIONS = {
     [OracleState.UNSPECIFIED]: [],
-    [OracleState.REGISTERED]: ['stake', 'withdraw'],
-    [OracleState.ACTIVE]: ['assign', 'unstake'],
-    [OracleState.ASSIGNED]: ['submit', 'timeout'],
-    [OracleState.SUBMITTED]: ['finalize', 'challenge'],
-    [OracleState.CHALLENGED]: ['uphold', 'overturn'],
-    [OracleState.SUSPENDED]: ['begin_probation', 'permanent_ban'],
+    [OracleState.UNREGISTERED]: ['register'],
+    [OracleState.REGISTERED]: ['activate', 'withdraw'],
+    [OracleState.ACTIVE]: ['add_stake', 'record_resolution', 'slash', 'withdraw'],
+    [OracleState.SLASHED]: ['reactivate', 'withdraw'],
     [OracleState.WITHDRAWN]: [], // Terminal state
 };
 /**

--- a/dist/types/apps/markets/index.d.ts
+++ b/dist/types/apps/markets/index.d.ts
@@ -10,8 +10,12 @@
  *   MarketState,
  *   MarketType,
  *   calculatePayout,
- *   DEFAULT_MARKET_CONFIG
+ *   DEFAULT_MARKET_CONFIG,
+ *   getMarketDefinition
  * } from '@ottochain/sdk/apps/markets';
+ *
+ * // Get the universal market state machine definition
+ * const marketDef = getMarketDefinition();
  *
  * // Calculate payout for a winning prediction
  * const payout = calculatePayout({
@@ -23,4 +27,21 @@
  *
  * @packageDocumentation
  */
+export * from '../../generated/ottochain/apps/markets/v1/market_pb.js';
 export * from './types.js';
+/**
+ * Market definition type.
+ * Currently universal - handles all market types via the same state machine.
+ */
+export type MarketDefinitionType = 'Universal';
+/**
+ * Market state machine definitions mapped by type.
+ */
+export declare const MARKET_DEFINITIONS: Record<MarketDefinitionType, unknown>;
+/**
+ * Get the market state machine definition.
+ *
+ * @param type - Definition type (default: 'Universal')
+ * @returns The state machine definition JSON
+ */
+export declare function getMarketDefinition(type?: MarketDefinitionType): unknown;

--- a/dist/types/apps/markets/types.d.ts
+++ b/dist/types/apps/markets/types.d.ts
@@ -3,42 +3,12 @@
  *
  * Constants, types, and utilities for the Markets application on OttoChain.
  *
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (MarketType, MarketState, Market, Commitment, Resolution) are
+ * exported from proto-generated types in index.ts.
  *
  * @packageDocumentation
  */
-/**
- * Market lifecycle states
- */
-export declare enum MarketState {
-    UNSPECIFIED = 0,
-    /** Market is open for commitments */
-    OPEN = 1,
-    /** Commitment period has ended, awaiting resolution */
-    CLOSED = 2,
-    /** Oracle has resolved the outcome */
-    RESOLVED = 3,
-    /** Payouts distributed to winners */
-    SETTLED = 4,
-    /** Market cancelled, refunds issued */
-    CANCELLED = 5,
-    /** Market is disputed */
-    DISPUTED = 6
-}
-/**
- * Types of markets supported
- */
-export declare enum MarketType {
-    UNSPECIFIED = 0,
-    /** Binary or multi-outcome prediction market */
-    PREDICTION = 1,
-    /** Ascending/descending price auction */
-    AUCTION = 2,
-    /** All-or-nothing crowdfunding */
-    CROWDFUND = 3,
-    /** Group buying with volume discounts */
-    GROUP_BUY = 4
-}
+import { MarketType, MarketState } from '../../generated/ottochain/apps/markets/v1/market_pb.js';
 /**
  * Commitment direction (for prediction markets)
  */
@@ -77,7 +47,7 @@ export declare const DEFAULT_MARKET_CONFIG: MarketConfig;
  */
 export declare const MARKET_TYPE_CONFIGS: Record<MarketType, Partial<MarketConfig>>;
 /**
- * Valid transitions for each market state
+ * Valid transitions for each market state (aligned with proto MarketState enum)
  */
 export declare const MARKET_TRANSITIONS: Record<MarketState, readonly string[]>;
 /**

--- a/dist/types/apps/oracles/index.d.ts
+++ b/dist/types/apps/oracles/index.d.ts
@@ -11,8 +11,12 @@
  *   SlashingReason,
  *   calculateReputation,
  *   calculateSlashAmount,
- *   DEFAULT_ORACLE_CONFIG
+ *   DEFAULT_ORACLE_CONFIG,
+ *   getOracleDefinition
  * } from '@ottochain/sdk/apps/oracles';
+ *
+ * // Get the oracle state machine definition
+ * const oracleDef = getOracleDefinition();
  *
  * // Calculate new reputation after successful resolution
  * const newRep = calculateReputation(50, REPUTATION_DELTAS.successfulResolution);
@@ -23,4 +27,20 @@
  *
  * @packageDocumentation
  */
+export * from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
 export * from './types.js';
+/**
+ * Oracle definition type.
+ */
+export type OracleDefinitionType = 'Oracle';
+/**
+ * Oracle state machine definitions mapped by type.
+ */
+export declare const ORACLE_DEFINITIONS: Record<OracleDefinitionType, unknown>;
+/**
+ * Get the oracle state machine definition.
+ *
+ * @param type - Definition type (default: 'Oracle')
+ * @returns The state machine definition JSON
+ */
+export declare function getOracleDefinition(type?: OracleDefinitionType): unknown;

--- a/dist/types/apps/oracles/types.d.ts
+++ b/dist/types/apps/oracles/types.d.ts
@@ -4,30 +4,12 @@
  * Constants, types, and utilities for the Oracle system on OttoChain.
  * Oracles provide truth resolution for markets and disputes.
  *
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (OracleState, Oracle, etc.) are exported from proto-generated
+ * types in index.ts.
  *
  * @packageDocumentation
  */
-/**
- * Oracle lifecycle states
- */
-export declare enum OracleState {
-    UNSPECIFIED = 0,
-    /** Oracle has registered but not yet staked */
-    REGISTERED = 1,
-    /** Oracle is staked and available for assignments */
-    ACTIVE = 2,
-    /** Oracle is currently assigned to resolve a market */
-    ASSIGNED = 3,
-    /** Oracle has submitted a resolution, in challenge period */
-    SUBMITTED = 4,
-    /** Oracle is under review due to dispute */
-    CHALLENGED = 5,
-    /** Oracle is suspended due to slashing */
-    SUSPENDED = 6,
-    /** Oracle has withdrawn stake and exited */
-    WITHDRAWN = 7
-}
+import { OracleState } from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
 /**
  * Types of oracle resolutions
  */
@@ -92,7 +74,7 @@ export declare const DEFAULT_ORACLE_CONFIG: OracleConfig;
  */
 export declare const SLASHING_PERCENTAGES: Record<SlashingReason, number>;
 /**
- * Valid transitions for each oracle state
+ * Valid transitions for each oracle state (aligned with proto OracleState enum)
  */
 export declare const ORACLE_TRANSITIONS: Record<OracleState, readonly string[]>;
 /**

--- a/src/apps/markets/index.ts
+++ b/src/apps/markets/index.ts
@@ -10,8 +10,12 @@
  *   MarketState, 
  *   MarketType,
  *   calculatePayout,
- *   DEFAULT_MARKET_CONFIG 
+ *   DEFAULT_MARKET_CONFIG,
+ *   getMarketDefinition
  * } from '@ottochain/sdk/apps/markets';
+ * 
+ * // Get the universal market state machine definition
+ * const marketDef = getMarketDefinition();
  * 
  * // Calculate payout for a winning prediction
  * const payout = calculatePayout({
@@ -24,9 +28,41 @@
  * @packageDocumentation
  */
 
-// Note: Once proto files are generated, uncomment these exports:
-// export * from '../../generated/ottochain/apps/markets/v1/market_pb.js';
-// export * from '../../generated/ottochain/apps/markets/v1/commitment_pb.js';
+// Re-export generated protobuf types
+export * from '../../generated/ottochain/apps/markets/v1/market_pb.js';
 
 // Export convenience types, constants, and helpers
 export * from './types.js';
+
+// ---------------------------------------------------------------------------
+// State Machine JSON Definitions
+// ---------------------------------------------------------------------------
+
+import marketUniversalDef from './state-machines/market-universal.json';
+
+/**
+ * Market definition type.
+ * Currently universal - handles all market types via the same state machine.
+ */
+export type MarketDefinitionType = 'Universal';
+
+/**
+ * Market state machine definitions mapped by type.
+ */
+export const MARKET_DEFINITIONS: Record<MarketDefinitionType, unknown> = {
+  Universal: marketUniversalDef,
+};
+
+/**
+ * Get the market state machine definition.
+ * 
+ * @param type - Definition type (default: 'Universal')
+ * @returns The state machine definition JSON
+ */
+export function getMarketDefinition(type: MarketDefinitionType = 'Universal'): unknown {
+  const def = MARKET_DEFINITIONS[type];
+  if (!def) {
+    throw new Error(`Unknown market definition type: ${type}`);
+  }
+  return def;
+}

--- a/src/apps/markets/state-machines/market-universal.json
+++ b/src/apps/markets/state-machines/market-universal.json
@@ -1,0 +1,280 @@
+{
+  "metadata": {
+    "name": "Market",
+    "description": "Universal market state machine: predictions, auctions, crowdfunding, group buys",
+    "version": "1.0.0"
+  },
+  "states": {
+    "PROPOSED": { "id": { "value": "PROPOSED" }, "isFinal": false },
+    "OPEN": { "id": { "value": "OPEN" }, "isFinal": false },
+    "CLOSED": { "id": { "value": "CLOSED" }, "isFinal": false },
+    "RESOLVING": { "id": { "value": "RESOLVING" }, "isFinal": false },
+    "SETTLED": { "id": { "value": "SETTLED" }, "isFinal": true },
+    "REFUNDED": { "id": { "value": "REFUNDED" }, "isFinal": true },
+    "CANCELLED": { "id": { "value": "CANCELLED" }, "isFinal": true }
+  },
+  "initialState": { "value": "PROPOSED" },
+  "transitions": [
+    {
+      "_comment": "Creator opens the market for participation",
+      "from": { "value": "PROPOSED" },
+      "to": { "value": "OPEN" },
+      "eventName": "open",
+      "guard": { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "OPEN", "openedAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Creator cancels before opening",
+      "from": { "value": "PROPOSED" },
+      "to": { "value": "CANCELLED" },
+      "eventName": "cancel",
+      "guard": { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "CANCELLED", "cancelledAt": { "var": "$timestamp" }, "reason": { "var": "event.reason" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Participant commits resources (stake/bid/pledge/order)",
+      "from": { "value": "OPEN" },
+      "to": { "value": "OPEN" },
+      "eventName": "commit",
+      "guard": {
+        "and": [
+          { ">": [{ "var": "event.amount" }, 0] },
+          { "or": [
+            { "!": { "var": "state.deadline" } },
+            { "<=": [{ "var": "$timestamp" }, { "var": "state.deadline" }] }
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "commitments": {
+              "setKey": [
+                { "var": "state.commitments" },
+                { "var": "event.agent" },
+                {
+                  "merge": [
+                    { "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }, { "amount": 0, "data": {} }] },
+                    {
+                      "amount": { "+": [
+                        { "getKey": [{ "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }, { "amount": 0 }] }, "amount", 0] },
+                        { "var": "event.amount" }
+                      ]},
+                      "data": { "var": "event.data" },
+                      "lastCommitAt": { "var": "$timestamp" }
+                    }
+                  ]
+                }
+              ]
+            },
+            "totalCommitted": { "+": [{ "var": "state.totalCommitted" }, { "var": "event.amount" }] }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Close market for new commitments (manual or deadline)",
+      "from": { "value": "OPEN" },
+      "to": { "value": "CLOSED" },
+      "eventName": "close",
+      "guard": {
+        "or": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+          { "and": [
+            { "var": "state.deadline" },
+            { ">=": [{ "var": "$timestamp" }, { "var": "state.deadline" }] }
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "CLOSED", "closedAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Submit resolution (oracle/auctioneer/system)",
+      "from": { "value": "CLOSED" },
+      "to": { "value": "RESOLVING" },
+      "eventName": "submit_resolution",
+      "guard": {
+        "or": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.oracles" }] },
+          { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "RESOLVING",
+            "resolutions": {
+              "cat": [
+                { "var": "state.resolutions" },
+                [{
+                  "oracle": { "var": "event.agent" },
+                  "outcome": { "var": "event.outcome" },
+                  "proof": { "var": "event.proof" },
+                  "submittedAt": { "var": "$timestamp" }
+                }]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Additional oracle votes during resolution",
+      "from": { "value": "RESOLVING" },
+      "to": { "value": "RESOLVING" },
+      "eventName": "submit_resolution",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.oracles" }] },
+          { "!": { "in": [{ "var": "event.agent" }, { "map": [{ "var": "state.resolutions" }, { "var": "oracle" }] }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "resolutions": {
+              "cat": [
+                { "var": "state.resolutions" },
+                [{
+                  "oracle": { "var": "event.agent" },
+                  "outcome": { "var": "event.outcome" },
+                  "proof": { "var": "event.proof" },
+                  "submittedAt": { "var": "$timestamp" }
+                }]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Finalize when quorum reached or threshold met",
+      "from": { "value": "RESOLVING" },
+      "to": { "value": "SETTLED" },
+      "eventName": "finalize",
+      "guard": {
+        "or": [
+          { ">=": [{ "size": { "var": "state.resolutions" } }, { "var": "state.quorum" }] },
+          { "===": [{ "var": "state.marketType" }, "crowdfund"] },
+          { "===": [{ "var": "state.marketType" }, "group_buy"] },
+          { "===": [{ "var": "state.marketType" }, "auction"] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "SETTLED",
+            "settledAt": { "var": "$timestamp" },
+            "finalOutcome": { "var": "event.outcome" },
+            "settlement": { "var": "event.settlement" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Refund if threshold not met",
+      "from": { "value": "CLOSED" },
+      "to": { "value": "REFUNDED" },
+      "eventName": "refund",
+      "guard": {
+        "and": [
+          { "var": "state.threshold" },
+          { "<": [{ "var": "state.totalCommitted" }, { "var": "state.threshold" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "REFUNDED", "refundedAt": { "var": "$timestamp" }, "reason": "threshold_not_met" }
+        ]
+      }
+    },
+    {
+      "_comment": "Refund from resolving if disputed/failed",
+      "from": { "value": "RESOLVING" },
+      "to": { "value": "REFUNDED" },
+      "eventName": "refund",
+      "guard": {
+        "or": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.creator" }] },
+          { ">=": [{ "size": { "filter": [{ "var": "state.resolutions" }, { "===": [{ "var": "outcome" }, "INVALID"] }] } }, { "var": "state.quorum" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "REFUNDED", "refundedAt": { "var": "$timestamp" }, "reason": { "var": "event.reason" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Claim winnings/rewards after settlement",
+      "from": { "value": "SETTLED" },
+      "to": { "value": "SETTLED" },
+      "eventName": "claim",
+      "guard": {
+        "and": [
+          { "getKey": [{ "var": "state.commitments" }, { "var": "event.agent" }] },
+          { "!": { "getKey": [{ "var": "state.claims" }, { "var": "event.agent" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "claims": {
+              "setKey": [
+                { "var": "state.claims" },
+                { "var": "event.agent" },
+                { "claimedAt": { "var": "$timestamp" }, "amount": { "var": "event.amount" } }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "_comment": "Template for creating new markets",
+    "schema": "Market",
+    "marketType": "prediction | auction | crowdfund | group_buy",
+    "creator": "<address>",
+    "title": "",
+    "description": "",
+    "terms": {
+      "_comment": "Type-specific configuration",
+      "prediction": { "question": "", "outcomes": ["YES", "NO"], "feePercent": 2 },
+      "auction": { "item": "", "reservePrice": 0, "buyNowPrice": null },
+      "crowdfund": { "goal": 0, "rewards": [], "allOrNothing": true },
+      "group_buy": { "product": "", "unitPrice": 0, "bulkPrice": 0, "minUnits": 0 }
+    },
+    "deadline": null,
+    "threshold": null,
+    "oracles": [],
+    "quorum": 1,
+    "commitments": {},
+    "totalCommitted": 0,
+    "resolutions": [],
+    "claims": {},
+    "status": "PROPOSED"
+  }
+}

--- a/src/apps/markets/types.ts
+++ b/src/apps/markets/types.ts
@@ -3,48 +3,13 @@
  * 
  * Constants, types, and utilities for the Markets application on OttoChain.
  * 
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (MarketType, MarketState, Market, Commitment, Resolution) are
+ * exported from proto-generated types in index.ts.
  * 
  * @packageDocumentation
  */
 
-// ---------------------------------------------------------------------------
-// Enums (will be replaced by proto-generated versions)
-// ---------------------------------------------------------------------------
-
-/**
- * Market lifecycle states
- */
-export enum MarketState {
-  UNSPECIFIED = 0,
-  /** Market is open for commitments */
-  OPEN = 1,
-  /** Commitment period has ended, awaiting resolution */
-  CLOSED = 2,
-  /** Oracle has resolved the outcome */
-  RESOLVED = 3,
-  /** Payouts distributed to winners */
-  SETTLED = 4,
-  /** Market cancelled, refunds issued */
-  CANCELLED = 5,
-  /** Market is disputed */
-  DISPUTED = 6,
-}
-
-/**
- * Types of markets supported
- */
-export enum MarketType {
-  UNSPECIFIED = 0,
-  /** Binary or multi-outcome prediction market */
-  PREDICTION = 1,
-  /** Ascending/descending price auction */
-  AUCTION = 2,
-  /** All-or-nothing crowdfunding */
-  CROWDFUND = 3,
-  /** Group buying with volume discounts */
-  GROUP_BUY = 4,
-}
+import { MarketType, MarketState } from '../../generated/ottochain/apps/markets/v1/market_pb.js';
 
 /**
  * Commitment direction (for prediction markets)
@@ -128,16 +93,17 @@ export const MARKET_TYPE_CONFIGS: Record<MarketType, Partial<MarketConfig>> = {
 // ---------------------------------------------------------------------------
 
 /**
- * Valid transitions for each market state
+ * Valid transitions for each market state (aligned with proto MarketState enum)
  */
 export const MARKET_TRANSITIONS: Record<MarketState, readonly string[]> = {
   [MarketState.UNSPECIFIED]: [],
-  [MarketState.OPEN]: ['close', 'cancel'],
-  [MarketState.CLOSED]: ['resolve', 'dispute', 'cancel'],
-  [MarketState.RESOLVED]: ['settle', 'dispute'],
-  [MarketState.SETTLED]: [],       // Terminal state
-  [MarketState.CANCELLED]: [],     // Terminal state
-  [MarketState.DISPUTED]: ['resolve_dispute', 'cancel'],
+  [MarketState.PROPOSED]: ['open', 'cancel'],
+  [MarketState.OPEN]: ['close', 'cancel', 'commit'],
+  [MarketState.CLOSED]: ['submit_resolution', 'refund'],
+  [MarketState.RESOLVING]: ['submit_resolution', 'finalize', 'refund'],
+  [MarketState.SETTLED]: ['claim'],  // Terminal (only claims allowed)
+  [MarketState.REFUNDED]: [],        // Terminal state
+  [MarketState.CANCELLED]: [],       // Terminal state
 };
 
 /**
@@ -146,6 +112,7 @@ export const MARKET_TRANSITIONS: Record<MarketState, readonly string[]> = {
 export function isTerminalMarketState(state: MarketState): boolean {
   return [
     MarketState.SETTLED,
+    MarketState.REFUNDED,
     MarketState.CANCELLED,
   ].includes(state);
 }

--- a/src/apps/oracles/index.ts
+++ b/src/apps/oracles/index.ts
@@ -11,8 +11,12 @@
  *   SlashingReason,
  *   calculateReputation,
  *   calculateSlashAmount,
- *   DEFAULT_ORACLE_CONFIG 
+ *   DEFAULT_ORACLE_CONFIG,
+ *   getOracleDefinition
  * } from '@ottochain/sdk/apps/oracles';
+ * 
+ * // Get the oracle state machine definition
+ * const oracleDef = getOracleDefinition();
  * 
  * // Calculate new reputation after successful resolution
  * const newRep = calculateReputation(50, REPUTATION_DELTAS.successfulResolution);
@@ -24,9 +28,40 @@
  * @packageDocumentation
  */
 
-// Note: Once proto files are generated, uncomment these exports:
-// export * from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
-// export * from '../../generated/ottochain/apps/oracles/v1/resolution_pb.js';
+// Re-export generated protobuf types
+export * from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
 
 // Export convenience types, constants, and helpers
 export * from './types.js';
+
+// ---------------------------------------------------------------------------
+// State Machine JSON Definitions
+// ---------------------------------------------------------------------------
+
+import oracleDef from './state-machines/oracle.json';
+
+/**
+ * Oracle definition type.
+ */
+export type OracleDefinitionType = 'Oracle';
+
+/**
+ * Oracle state machine definitions mapped by type.
+ */
+export const ORACLE_DEFINITIONS: Record<OracleDefinitionType, unknown> = {
+  Oracle: oracleDef,
+};
+
+/**
+ * Get the oracle state machine definition.
+ * 
+ * @param type - Definition type (default: 'Oracle')
+ * @returns The state machine definition JSON
+ */
+export function getOracleDefinition(type: OracleDefinitionType = 'Oracle'): unknown {
+  const def = ORACLE_DEFINITIONS[type];
+  if (!def) {
+    throw new Error(`Unknown oracle definition type: ${type}`);
+  }
+  return def;
+}

--- a/src/apps/oracles/state-machines/oracle.json
+++ b/src/apps/oracles/state-machines/oracle.json
@@ -1,0 +1,211 @@
+{
+  "metadata": {
+    "name": "Oracle",
+    "description": "Oracle registration, reputation, and slashing state machine",
+    "version": "1.0.0"
+  },
+  "states": {
+    "UNREGISTERED": { "id": { "value": "UNREGISTERED" }, "isFinal": false },
+    "REGISTERED": { "id": { "value": "REGISTERED" }, "isFinal": false },
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "SLASHED": { "id": { "value": "SLASHED" }, "isFinal": false },
+    "WITHDRAWN": { "id": { "value": "WITHDRAWN" }, "isFinal": true }
+  },
+  "initialState": { "value": "UNREGISTERED" },
+  "transitions": [
+    {
+      "_comment": "Register as oracle with initial stake",
+      "from": { "value": "UNREGISTERED" },
+      "to": { "value": "REGISTERED" },
+      "eventName": "register",
+      "guard": {
+        ">=": [{ "var": "event.stake" }, { "var": "state.minStake" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "REGISTERED",
+            "address": { "var": "event.agent" },
+            "stake": { "var": "event.stake" },
+            "registeredAt": { "var": "$timestamp" },
+            "reputation": { "accuracy": 100, "totalResolutions": 0, "disputesWon": 0, "disputesLost": 0 },
+            "domains": { "var": "event.domains" },
+            "slashingHistory": []
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Activate oracle after verification period",
+      "from": { "value": "REGISTERED" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "activate",
+      "guard": {
+        "or": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+          { "var": "event.adminOverride" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "ACTIVE", "activatedAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Add more stake",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "add_stake",
+      "guard": {
+        "and": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+          { ">": [{ "var": "event.amount" }, 0] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "stake": { "+": [{ "var": "state.stake" }, { "var": "event.amount" }] },
+            "lastStakeAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Record successful resolution (called by market settlement)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "record_resolution",
+      "guard": { "var": "event.marketId" },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "reputation": {
+              "merge": [
+                { "var": "state.reputation" },
+                {
+                  "totalResolutions": { "+": [{ "var": "state.reputation.totalResolutions" }, 1] },
+                  "accuracy": {
+                    "if": [
+                      { "var": "event.correct" },
+                      { "var": "state.reputation.accuracy" },
+                      { "-": [{ "var": "state.reputation.accuracy" }, 5] }
+                    ]
+                  }
+                }
+              ]
+            },
+            "lastResolutionAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Slash oracle for misbehavior",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "SLASHED" },
+      "eventName": "slash",
+      "guard": {
+        "and": [
+          { "var": "event.reason" },
+          { ">": [{ "var": "event.amount" }, 0] },
+          { "<=": [{ "var": "event.amount" }, { "var": "state.stake" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "SLASHED",
+            "stake": { "-": [{ "var": "state.stake" }, { "var": "event.amount" }] },
+            "slashingHistory": {
+              "cat": [
+                { "var": "state.slashingHistory" },
+                [{
+                  "reason": { "var": "event.reason" },
+                  "amount": { "var": "event.amount" },
+                  "marketId": { "var": "event.marketId" },
+                  "slashedAt": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "slashedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Reactivate after slash cooldown",
+      "from": { "value": "SLASHED" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "reactivate",
+      "guard": {
+        "and": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+          { ">=": [{ "var": "state.stake" }, { "var": "state.minStake" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "ACTIVE", "reactivatedAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Withdraw from oracle role",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "WITHDRAWN" },
+      "eventName": "withdraw",
+      "guard": { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "WITHDRAWN",
+            "withdrawnAt": { "var": "$timestamp" },
+            "finalStake": { "var": "state.stake" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Withdraw after slash (may have reduced stake)",
+      "from": { "value": "SLASHED" },
+      "to": { "value": "WITHDRAWN" },
+      "eventName": "withdraw",
+      "guard": { "===": [{ "var": "event.agent" }, { "var": "state.address" }] },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "WITHDRAWN",
+            "withdrawnAt": { "var": "$timestamp" },
+            "finalStake": { "var": "state.stake" }
+          }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "_comment": "Template for creating new oracle registrations",
+    "schema": "Oracle",
+    "address": "<address>",
+    "stake": 0,
+    "minStake": 100,
+    "reputation": {
+      "accuracy": 100,
+      "totalResolutions": 0,
+      "disputesWon": 0,
+      "disputesLost": 0
+    },
+    "domains": [],
+    "slashingHistory": [],
+    "status": "UNREGISTERED"
+  }
+}

--- a/src/apps/oracles/types.ts
+++ b/src/apps/oracles/types.ts
@@ -4,35 +4,13 @@
  * Constants, types, and utilities for the Oracle system on OttoChain.
  * Oracles provide truth resolution for markets and disputes.
  * 
- * Note: When proto files are generated, enums will move to generated types.
+ * Core types (OracleState, Oracle, etc.) are exported from proto-generated 
+ * types in index.ts.
  * 
  * @packageDocumentation
  */
 
-// ---------------------------------------------------------------------------
-// Enums (will be replaced by proto-generated versions)
-// ---------------------------------------------------------------------------
-
-/**
- * Oracle lifecycle states
- */
-export enum OracleState {
-  UNSPECIFIED = 0,
-  /** Oracle has registered but not yet staked */
-  REGISTERED = 1,
-  /** Oracle is staked and available for assignments */
-  ACTIVE = 2,
-  /** Oracle is currently assigned to resolve a market */
-  ASSIGNED = 3,
-  /** Oracle has submitted a resolution, in challenge period */
-  SUBMITTED = 4,
-  /** Oracle is under review due to dispute */
-  CHALLENGED = 5,
-  /** Oracle is suspended due to slashing */
-  SUSPENDED = 6,
-  /** Oracle has withdrawn stake and exited */
-  WITHDRAWN = 7,
-}
+import { OracleState } from '../../generated/ottochain/apps/oracles/v1/oracle_pb.js';
 
 /**
  * Types of oracle resolutions
@@ -129,16 +107,14 @@ export const SLASHING_PERCENTAGES: Record<SlashingReason, number> = {
 // ---------------------------------------------------------------------------
 
 /**
- * Valid transitions for each oracle state
+ * Valid transitions for each oracle state (aligned with proto OracleState enum)
  */
 export const ORACLE_TRANSITIONS: Record<OracleState, readonly string[]> = {
   [OracleState.UNSPECIFIED]: [],
-  [OracleState.REGISTERED]: ['stake', 'withdraw'],
-  [OracleState.ACTIVE]: ['assign', 'unstake'],
-  [OracleState.ASSIGNED]: ['submit', 'timeout'],
-  [OracleState.SUBMITTED]: ['finalize', 'challenge'],
-  [OracleState.CHALLENGED]: ['uphold', 'overturn'],
-  [OracleState.SUSPENDED]: ['begin_probation', 'permanent_ban'],
+  [OracleState.UNREGISTERED]: ['register'],
+  [OracleState.REGISTERED]: ['activate', 'withdraw'],
+  [OracleState.ACTIVE]: ['add_stake', 'record_resolution', 'slash', 'withdraw'],
+  [OracleState.SLASHED]: ['reactivate', 'withdraw'],
   [OracleState.WITHDRAWN]: [],  // Terminal state
 };
 


### PR DESCRIPTION
## Summary
Makes the three domain apps (governance, markets, oracles) symmetric in their exports:

### Changes
- **Proto type exports**: markets/index.ts and oracles/index.ts now export proto types
- **State machine JSONs**: Added `state-machines/` folders with definitions
  - `markets/state-machines/market-universal.json`
  - `oracles/state-machines/oracle.json`
- **Definition getters**: Added `getMarketDefinition()` and `getOracleDefinition()` helpers
- **Removed duplicate enums**: types.ts now imports from proto (single source of truth)
- **Aligned state transitions**: Updated to match proto enum values

### Symmetry Achieved
All three domain apps now have:
1. ✅ Proto type exports
2. ✅ State machine JSON definitions
3. ✅ `getXxxDefinition()` helpers
4. ✅ Helper functions and constants

### Usage Example
```typescript
import { 
  MarketState, 
  MarketType, 
  getMarketDefinition,
  calculatePayout 
} from '@ottochain/sdk/apps/markets';

import {
  OracleState,
  getOracleDefinition,
  calculateSlashAmount
} from '@ottochain/sdk/apps/oracles';

// Get state machine definitions
const marketDef = getMarketDefinition();
const oracleDef = getOracleDefinition();
```

---
Follows from SDK PR #8 (proto type exports).