### PR TITLE
fix: add subpath exports for all apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,31 @@
       "import": "./dist/esm/apps/contracts/index.js",
       "require": "./dist/cjs/apps/contracts/index.js",
       "types": "./dist/types/apps/contracts/index.d.ts"
+    },
+    "./apps/markets": {
+      "import": "./dist/esm/apps/markets/index.js",
+      "require": "./dist/cjs/apps/markets/index.js",
+      "types": "./dist/types/apps/markets/index.d.ts"
+    },
+    "./apps/oracles": {
+      "import": "./dist/esm/apps/oracles/index.js",
+      "require": "./dist/cjs/apps/oracles/index.js",
+      "types": "./dist/types/apps/oracles/index.d.ts"
+    },
+    "./apps/governance": {
+      "import": "./dist/esm/apps/governance/index.js",
+      "require": "./dist/cjs/apps/governance/index.js",
+      "types": "./dist/types/apps/governance/index.d.ts"
+    },
+    "./apps/corporate": {
+      "import": "./dist/esm/apps/corporate/index.js",
+      "require": "./dist/cjs/apps/corporate/index.js",
+      "types": "./dist/types/apps/corporate/index.d.ts"
+    },
+    "./apps": {
+      "import": "./dist/esm/apps/index.js",
+      "require": "./dist/cjs/apps/index.js",
+      "types": "./dist/types/apps/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Adds package.json exports for all app subpaths:

- `./apps/markets`
- `./apps/oracles`
- `./apps/governance`
- `./apps/corporate`
- `./apps` (all apps namespace)

Enables imports like:
```typescript
import { getMarketDefinition, MarketType } from '@ottochain/sdk/apps/markets';
import { getOracleDefinition } from '@ottochain/sdk/apps/oracles';
import { getDAODefinition } from '@ottochain/sdk/apps/governance';
```

Needed for bridge to import definitions from SDK instead of hardcoding.