### PR TITLE
feat: sync message and query types with chain registry surface

### DIFF
--- a/proto/ottochain/v1/common.proto
+++ b/proto/ottochain/v1/common.proto
@@ -6,21 +6,136 @@ package ottochain.v1;
 // OttoChain Common Types
 // =============================================================================
 //
-// This file previously defined wrapper messages (Address, FiberOrdinal, etc.)
-// but these have been removed in favor of plain primitives for wire format
-// compatibility with the metagraph's JSON Logic engine.
-//
-// The metagraph stores addresses as plain strings in JsonLogicValue:
-//   "signers" -> ArrayValue(List(StrValue("DAG1..."), StrValue("DAG2...")))
-//
-// TypeScript type aliases are provided in src/types.ts for semantic meaning.
-// =============================================================================
-
-// Note: All wrapper messages removed. Use string/int64 directly in proto files.
-// See src/types.ts for TypeScript type aliases:
+// Primitive wire values (Address, FiberId, FiberOrdinal, etc.) are plain
+// string/int64 — see src/types.ts for the TypeScript aliases:
 //   - Address = string (DAG address)
 //   - FiberId = string (UUID)
 //   - StateId = string (state machine state identifier)
 //   - HashValue = string (hex-encoded hash)
 //   - FiberOrdinal = number (sequence number)
 //   - SnapshotOrdinal = number (Constellation snapshot ordinal)
+//   - SemVer = string ("MAJOR.MINOR.PATCH")
+//
+// This file holds the registry/versioning/schema-shape types shared by the
+// message and query surfaces.
+// =============================================================================
+
+// Lifecycle status of a registered version (npm/Cargo-style).
+//   - ACTIVE     — selectable + recommended.
+//   - DEPRECATED — still resolvable/runnable, flagged, discouraged for new instances.
+//   - YANKED     — excluded from NEW resolutions; existing pinned fibers keep running.
+enum RegistryStatus {
+  REGISTRY_STATUS_UNSPECIFIED = 0;
+  ACTIVE = 1;
+  DEPRECATED = 2;
+  YANKED = 3;
+}
+
+// A caller's version requirement, resolved against a VersionLineage (Cargo/npm-style).
+// On the JSON wire it is a single-key wrapper object: {"Exact":{"version":"1.0.0"}}, {"Latest":{}}, ...
+message VersionReq {
+  oneof requirement {
+    ExactVersion exact = 1;        // exactly this version
+    CaretVersion caret = 2;        // same MAJOR and >= v (^1.2.0)
+    TildeVersion tilde = 3;        // same MAJOR.MINOR and >= v (~1.2.0)
+    LatestVersion latest = 4;      // highest selectable version
+    PinnedHashVersion pinned_hash = 5; // exact artifact by schema hash
+  }
+}
+
+message ExactVersion {
+  string version = 1; // SemVer string
+}
+
+message CaretVersion {
+  string version = 1; // SemVer string
+}
+
+message TildeVersion {
+  string version = 1; // SemVer string
+}
+
+message LatestVersion {}
+
+message PinnedHashVersion {
+  string schema_hash = 1; // Hash value
+}
+
+// A caller's reference to a registered schema/program version, supplied at fiber creation.
+message SchemaRef {
+  string name = 1; // Full registry name "labels.tld" (e.g. "counter.package")
+  VersionReq version = 2;
+}
+
+// One field of a MessageShape — mirrors a protobuf FieldDescriptorProto at the field level.
+message FieldShape {
+  string name = 1;
+  int32 number = 2;
+  string type_name = 3;
+  bool repeated = 4;  // default false
+  bool optional = 5;  // default false
+}
+
+// A single protobuf message shape: its type name plus its fields.
+message MessageShape {
+  string type_name = 1;
+  repeated FieldShape fields = 2;
+}
+
+// The on-chain projection of a version's proto schema: the State message plus one
+// message per command/event (keyed by event name). Publisher-claimed and advisory.
+message SchemaShape {
+  MessageShape state_message = 1;
+  map<string, MessageShape> commands = 2; // keyed by event name
+}
+
+// The resolved, pinned binding recorded on a fiber: which registry (name, version) it
+// instantiates, with the committed hashes.
+message SchemaBinding {
+  string name = 1;        // Full registry name "labels.tld"
+  string version = 2;     // SemVer string
+  string schema_hash = 3; // Hash value (descriptor commitment)
+  string logic_hash = 4;  // Hash value (verified-binding anchor)
+}
+
+// One immutable version of a registry entry.
+message RegisteredVersion {
+  string version = 1;      // SemVer string
+  string schema_hash = 2;  // Hash value (descriptor commitment)
+  string logic_hash = 3;   // Hash value (verified-binding anchor)
+  SchemaShape schema_shape = 4;
+  RegistryStatus status = 5;
+  int64 registered_at = 6; // Snapshot ordinal
+  bool strict = 7;         // default false
+}
+
+// The append-only, monotonic version lineage of a single registry entry.
+message VersionLineage {
+  map<string, RegisteredVersion> versions = 1; // SemVer-string keyed
+}
+
+// What a registry entry resolves to, discriminated by the name's TLD.
+// On the JSON wire it is a single-key wrapper object. Note the SchemaPackage double-nesting:
+// {"SchemaPackage":{"versions":{"versions":{"1.0.0":{...}}}}}.
+message RegistryTarget {
+  oneof target {
+    SchemaPackageTarget schema_package = 1; // .package — a versioned schema/program type
+    InstanceAliasTarget instance_alias = 2; // .machine / .script — a nickname for a fiber (#29)
+  }
+}
+
+message SchemaPackageTarget {
+  VersionLineage versions = 1;
+}
+
+message InstanceAliasTarget {
+  string fiber_id = 1;
+}
+
+// A single owned entry in the registry namespace.
+message RegistryEntry {
+  string name = 1;                   // Full registry name "labels.tld"
+  repeated string owner = 2;         // Owning DAG addresses
+  RegistryTarget target = 3;
+  map<string, string> metadata = 4;  // Optional off-chain links grab-bag
+}

--- a/proto/ottochain/v1/fiber.proto
+++ b/proto/ottochain/v1/fiber.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package ottochain.v1;
 
+import "ottochain/v1/common.proto";
 import "google/protobuf/struct.proto";
 
 // Fiber lifecycle status
@@ -73,10 +74,32 @@ message ScriptInvocation {
   string invoked_by = 7;  // DAG address
 }
 
-// Fiber log entry - union of event receipt or script invocation
+// Creation receipt - birth record for a fiber, emitted once at creation (#26/#30)
+message CreationReceipt {
+  string fiber_id = 1;
+  int64 ordinal = 2;  // Snapshot ordinal
+  string initial_state = 3;  // State ID
+  repeated string owners = 4;  // DAG addresses
+  optional SchemaBinding schema_binding = 5;
+  optional string parent_fiber_id = 6;
+}
+
+// Upgrade receipt - emitted when a fiber is upgraded to a different registered version (#27)
+message UpgradeReceipt {
+  string fiber_id = 1;
+  int64 ordinal = 2;  // Snapshot ordinal
+  optional SchemaBinding from_binding = 3;
+  SchemaBinding to_binding = 4;
+  int64 gas_used = 5;
+  bool migrated = 6;
+}
+
+// Fiber log entry - union of event receipt, script invocation, or lifecycle receipt
 message FiberLogEntry {
   oneof entry {
     EventReceipt event_receipt = 1;
     ScriptInvocation script_invocation = 2;
+    CreationReceipt creation_receipt = 3;
+    UpgradeReceipt upgrade_receipt = 4;
   }
 }

--- a/proto/ottochain/v1/messages.proto
+++ b/proto/ottochain/v1/messages.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package ottochain.v1;
 
 import "ottochain/v1/fiber.proto";
+import "ottochain/v1/common.proto";
 import "google/protobuf/struct.proto";
 
 // Create a new state machine fiber
@@ -11,6 +12,9 @@ message CreateStateMachine {
   StateMachineDefinition definition = 2;
   google.protobuf.Value initial_data = 3;
   optional string parent_fiber_id = 4;
+  // Optional reference to a registered schema/program version (#26). When present, the chain
+  // resolves it against the registry at create time and records the verified SchemaBinding.
+  optional SchemaRef schema_ref = 5;
 }
 
 // Trigger a state machine transition
@@ -25,6 +29,16 @@ message TransitionStateMachine {
 message ArchiveStateMachine {
   string fiber_id = 1;
   int64 target_sequence_number = 2;  // Fiber ordinal
+}
+
+// Upgrade an existing fiber to a different registered version of the SAME package (#27).
+message UpgradeFiber {
+  string fiber_id = 1;
+  SchemaRef target_ref = 2;
+  StateMachineDefinition new_definition = 3;
+  // Optional JSON-Logic transform applied to the prior state data during upgrade.
+  optional google.protobuf.Value migration = 4;
+  int64 target_sequence_number = 5;  // Fiber ordinal
 }
 
 // Create a new script fiber
@@ -43,6 +57,33 @@ message InvokeScript {
   int64 target_sequence_number = 4;  // Fiber ordinal
 }
 
+// Create-or-append a registry schema-package version (npm-publish semantics). The chain derives
+// the routing id from `name`, so there is no fiber_id on the wire.
+message PublishVersion {
+  string name = 1;            // Full registry name "labels.tld" (e.g. "order.package")
+  string version = 2;         // SemVer string "MAJOR.MINOR.PATCH"
+  string schema_b64 = 3;      // Base64 of the proto FileDescriptorSet (base64-validated + hashed, then dropped)
+  SchemaShape schema_shape = 4;
+  StateMachineDefinition definition = 5;
+  bool strict = 6;            // Opt-in runtime conformance gate (#33); default false
+  map<string, string> metadata = 7;  // Optional off-chain links grab-bag
+}
+
+// Change a registered version's lifecycle status (Active <-> Deprecated -> Yanked). Owner-gated.
+message SetVersionStatus {
+  string name = 1;            // Full registry name "labels.tld"
+  string version = 2;         // SemVer string
+  RegistryStatus status = 3;
+}
+
+// Register a human-readable nickname for an existing fiber (#29). The chain derives the routing id
+// from `name`, so there is no fiber_id on the wire.
+message RegisterAlias {
+  string name = 1;            // Full registry name "labels.tld" (e.g. "my-escrow.machine")
+  string target_fiber_id = 2; // The existing fiber UUID this alias points at
+  map<string, string> metadata = 3;  // Optional off-chain links grab-bag
+}
+
 // Union message type for all OttoChain operations
 message OttochainMessage {
   oneof message {
@@ -51,5 +92,9 @@ message OttochainMessage {
     ArchiveStateMachine archive_state_machine = 3;
     CreateScript create_script = 4;
     InvokeScript invoke_script = 5;
+    UpgradeFiber upgrade_fiber = 6;
+    PublishVersion publish_version = 7;
+    SetVersionStatus set_version_status = 8;
+    RegisterAlias register_alias = 9;
   }
 }

--- a/proto/ottochain/v1/records.proto
+++ b/proto/ottochain/v1/records.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package ottochain.v1;
 
 import "ottochain/v1/fiber.proto";
+import "ottochain/v1/common.proto";
 import "google/protobuf/struct.proto";
 
 // State machine fiber record - on-chain representation
@@ -21,6 +22,8 @@ message StateMachineFiberRecord {
   optional EventReceipt last_receipt = 12;
   optional string parent_fiber_id = 13;
   repeated string child_fiber_ids = 14;
+  // The resolved, pinned registry binding (#26), present when created from a registered version.
+  optional SchemaBinding schema_binding = 15;
 }
 
 // Script fiber record - on-chain representation
@@ -49,6 +52,8 @@ message FiberCommit {
 message OnChainState {
   map<string, FiberCommit> fiber_commits = 1;
   map<string, FiberLogEntryList> latest_logs = 2;
+  // Per-registry-entry commitment hash, keyed by full registry name "labels.tld".
+  map<string, string> registry_commits = 3;
 }
 
 // Helper for map of log entries
@@ -60,4 +65,10 @@ message FiberLogEntryList {
 message CalculatedState {
   map<string, StateMachineFiberRecord> state_machines = 1;
   map<string, ScriptFiberRecord> scripts = 2;
+  // Registry namespace, keyed by full registry name "labels.tld".
+  // Field is named `registry_entries` to avoid a synthetic map-entry name clash with the
+  // top-level RegistryEntry message; the JSON wire key stays `registry` via json_name.
+  map<string, RegistryEntry> registry_entries = 3 [json_name = "registry"];
+  // Reverse records (#29): fiber UUID -> its canonical registered name.
+  map<string, string> reverse_names = 4;
 }

--- a/src/generated/ottochain/v1/common.ts
+++ b/src/generated/ottochain/v1/common.ts
@@ -5,5 +5,2102 @@
 // source: ottochain/v1/common.proto
 
 /* eslint-disable */
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
 export const protobufPackage = "ottochain.v1";
+
+/**
+ * Lifecycle status of a registered version (npm/Cargo-style).
+ *   - ACTIVE     — selectable + recommended.
+ *   - DEPRECATED — still resolvable/runnable, flagged, discouraged for new instances.
+ *   - YANKED     — excluded from NEW resolutions; existing pinned fibers keep running.
+ */
+export enum RegistryStatus {
+  REGISTRY_STATUS_UNSPECIFIED = "REGISTRY_STATUS_UNSPECIFIED",
+  ACTIVE = "ACTIVE",
+  DEPRECATED = "DEPRECATED",
+  YANKED = "YANKED",
+  UNRECOGNIZED = "UNRECOGNIZED",
+}
+
+export function registryStatusFromJSON(object: any): RegistryStatus {
+  switch (object) {
+    case 0:
+    case "REGISTRY_STATUS_UNSPECIFIED":
+      return RegistryStatus.REGISTRY_STATUS_UNSPECIFIED;
+    case 1:
+    case "ACTIVE":
+      return RegistryStatus.ACTIVE;
+    case 2:
+    case "DEPRECATED":
+      return RegistryStatus.DEPRECATED;
+    case 3:
+    case "YANKED":
+      return RegistryStatus.YANKED;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return RegistryStatus.UNRECOGNIZED;
+  }
+}
+
+export function registryStatusToJSON(object: RegistryStatus): string {
+  switch (object) {
+    case RegistryStatus.REGISTRY_STATUS_UNSPECIFIED:
+      return "REGISTRY_STATUS_UNSPECIFIED";
+    case RegistryStatus.ACTIVE:
+      return "ACTIVE";
+    case RegistryStatus.DEPRECATED:
+      return "DEPRECATED";
+    case RegistryStatus.YANKED:
+      return "YANKED";
+    case RegistryStatus.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
+export function registryStatusToNumber(object: RegistryStatus): number {
+  switch (object) {
+    case RegistryStatus.REGISTRY_STATUS_UNSPECIFIED:
+      return 0;
+    case RegistryStatus.ACTIVE:
+      return 1;
+    case RegistryStatus.DEPRECATED:
+      return 2;
+    case RegistryStatus.YANKED:
+      return 3;
+    case RegistryStatus.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
+/**
+ * A caller's version requirement, resolved against a VersionLineage (Cargo/npm-style).
+ * On the JSON wire it is a single-key wrapper object: {"Exact":{"version":"1.0.0"}}, {"Latest":{}}, ...
+ */
+export interface VersionReq {
+  requirement?:
+    | //
+    /** exactly this version */
+    { $case: "exact"; exact: ExactVersion }
+    | //
+    /** same MAJOR and >= v (^1.2.0) */
+    { $case: "caret"; caret: CaretVersion }
+    | //
+    /** same MAJOR.MINOR and >= v (~1.2.0) */
+    { $case: "tilde"; tilde: TildeVersion }
+    | //
+    /** highest selectable version */
+    { $case: "latest"; latest: LatestVersion }
+    | //
+    /** exact artifact by schema hash */
+    { $case: "pinnedHash"; pinnedHash: PinnedHashVersion }
+    | undefined;
+}
+
+export interface ExactVersion {
+  /** SemVer string */
+  version: string;
+}
+
+export interface CaretVersion {
+  /** SemVer string */
+  version: string;
+}
+
+export interface TildeVersion {
+  /** SemVer string */
+  version: string;
+}
+
+export interface LatestVersion {
+}
+
+export interface PinnedHashVersion {
+  /** Hash value */
+  schemaHash: string;
+}
+
+/** A caller's reference to a registered schema/program version, supplied at fiber creation. */
+export interface SchemaRef {
+  /** Full registry name "labels.tld" (e.g. "counter.package") */
+  name: string;
+  version?: VersionReq | undefined;
+}
+
+/** One field of a MessageShape — mirrors a protobuf FieldDescriptorProto at the field level. */
+export interface FieldShape {
+  name: string;
+  number: number;
+  typeName: string;
+  /** default false */
+  repeated: boolean;
+  /** default false */
+  optional: boolean;
+}
+
+/** A single protobuf message shape: its type name plus its fields. */
+export interface MessageShape {
+  typeName: string;
+  fields: FieldShape[];
+}
+
+/**
+ * The on-chain projection of a version's proto schema: the State message plus one
+ * message per command/event (keyed by event name). Publisher-claimed and advisory.
+ */
+export interface SchemaShape {
+  stateMessage?:
+    | MessageShape
+    | undefined;
+  /** keyed by event name */
+  commands: { [key: string]: MessageShape };
+}
+
+export interface SchemaShape_CommandsEntry {
+  key: string;
+  value?: MessageShape | undefined;
+}
+
+/**
+ * The resolved, pinned binding recorded on a fiber: which registry (name, version) it
+ * instantiates, with the committed hashes.
+ */
+export interface SchemaBinding {
+  /** Full registry name "labels.tld" */
+  name: string;
+  /** SemVer string */
+  version: string;
+  /** Hash value (descriptor commitment) */
+  schemaHash: string;
+  /** Hash value (verified-binding anchor) */
+  logicHash: string;
+}
+
+/** One immutable version of a registry entry. */
+export interface RegisteredVersion {
+  /** SemVer string */
+  version: string;
+  /** Hash value (descriptor commitment) */
+  schemaHash: string;
+  /** Hash value (verified-binding anchor) */
+  logicHash: string;
+  schemaShape?: SchemaShape | undefined;
+  status: RegistryStatus;
+  /** Snapshot ordinal */
+  registeredAt: number;
+  /** default false */
+  strict: boolean;
+}
+
+/** The append-only, monotonic version lineage of a single registry entry. */
+export interface VersionLineage {
+  /** SemVer-string keyed */
+  versions: { [key: string]: RegisteredVersion };
+}
+
+export interface VersionLineage_VersionsEntry {
+  key: string;
+  value?: RegisteredVersion | undefined;
+}
+
+/**
+ * What a registry entry resolves to, discriminated by the name's TLD.
+ * On the JSON wire it is a single-key wrapper object. Note the SchemaPackage double-nesting:
+ * {"SchemaPackage":{"versions":{"versions":{"1.0.0":{...}}}}}.
+ */
+export interface RegistryTarget {
+  target?:
+    | //
+    /** .package — a versioned schema/program type */
+    { $case: "schemaPackage"; schemaPackage: SchemaPackageTarget }
+    | //
+    /** .machine / .script — a nickname for a fiber (#29) */
+    { $case: "instanceAlias"; instanceAlias: InstanceAliasTarget }
+    | undefined;
+}
+
+export interface SchemaPackageTarget {
+  versions?: VersionLineage | undefined;
+}
+
+export interface InstanceAliasTarget {
+  fiberId: string;
+}
+
+/** A single owned entry in the registry namespace. */
+export interface RegistryEntry {
+  /** Full registry name "labels.tld" */
+  name: string;
+  /** Owning DAG addresses */
+  owner: string[];
+  target?:
+    | RegistryTarget
+    | undefined;
+  /** Optional off-chain links grab-bag */
+  metadata: { [key: string]: string };
+}
+
+export interface RegistryEntry_MetadataEntry {
+  key: string;
+  value: string;
+}
+
+function createBaseVersionReq(): VersionReq {
+  return { requirement: undefined };
+}
+
+export const VersionReq: MessageFns<VersionReq> = {
+  encode(message: VersionReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    switch (message.requirement?.$case) {
+      case "exact":
+        ExactVersion.encode(message.requirement.exact, writer.uint32(10).fork()).join();
+        break;
+      case "caret":
+        CaretVersion.encode(message.requirement.caret, writer.uint32(18).fork()).join();
+        break;
+      case "tilde":
+        TildeVersion.encode(message.requirement.tilde, writer.uint32(26).fork()).join();
+        break;
+      case "latest":
+        LatestVersion.encode(message.requirement.latest, writer.uint32(34).fork()).join();
+        break;
+      case "pinnedHash":
+        PinnedHashVersion.encode(message.requirement.pinnedHash, writer.uint32(42).fork()).join();
+        break;
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VersionReq {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVersionReq();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.requirement = { $case: "exact", exact: ExactVersion.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.requirement = { $case: "caret", caret: CaretVersion.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.requirement = { $case: "tilde", tilde: TildeVersion.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.requirement = { $case: "latest", latest: LatestVersion.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.requirement = { $case: "pinnedHash", pinnedHash: PinnedHashVersion.decode(reader, reader.uint32()) };
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): VersionReq {
+    return {
+      requirement: isSet(object.exact)
+        ? { $case: "exact", exact: ExactVersion.fromJSON(object.exact) }
+        : isSet(object.caret)
+        ? { $case: "caret", caret: CaretVersion.fromJSON(object.caret) }
+        : isSet(object.tilde)
+        ? { $case: "tilde", tilde: TildeVersion.fromJSON(object.tilde) }
+        : isSet(object.latest)
+        ? { $case: "latest", latest: LatestVersion.fromJSON(object.latest) }
+        : isSet(object.pinnedHash)
+        ? { $case: "pinnedHash", pinnedHash: PinnedHashVersion.fromJSON(object.pinnedHash) }
+        : isSet(object.pinned_hash)
+        ? { $case: "pinnedHash", pinnedHash: PinnedHashVersion.fromJSON(object.pinned_hash) }
+        : undefined,
+    };
+  },
+
+  toJSON(message: VersionReq): unknown {
+    const obj: any = {};
+    if (message.requirement?.$case === "exact") {
+      obj.exact = ExactVersion.toJSON(message.requirement.exact);
+    } else if (message.requirement?.$case === "caret") {
+      obj.caret = CaretVersion.toJSON(message.requirement.caret);
+    } else if (message.requirement?.$case === "tilde") {
+      obj.tilde = TildeVersion.toJSON(message.requirement.tilde);
+    } else if (message.requirement?.$case === "latest") {
+      obj.latest = LatestVersion.toJSON(message.requirement.latest);
+    } else if (message.requirement?.$case === "pinnedHash") {
+      obj.pinnedHash = PinnedHashVersion.toJSON(message.requirement.pinnedHash);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<VersionReq>, I>>(base?: I): VersionReq {
+    return VersionReq.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<VersionReq>, I>>(object: I): VersionReq {
+    const message = createBaseVersionReq();
+    switch (object.requirement?.$case) {
+      case "exact": {
+        if (object.requirement?.exact !== undefined && object.requirement?.exact !== null) {
+          message.requirement = { $case: "exact", exact: ExactVersion.fromPartial(object.requirement.exact) };
+        }
+        break;
+      }
+      case "caret": {
+        if (object.requirement?.caret !== undefined && object.requirement?.caret !== null) {
+          message.requirement = { $case: "caret", caret: CaretVersion.fromPartial(object.requirement.caret) };
+        }
+        break;
+      }
+      case "tilde": {
+        if (object.requirement?.tilde !== undefined && object.requirement?.tilde !== null) {
+          message.requirement = { $case: "tilde", tilde: TildeVersion.fromPartial(object.requirement.tilde) };
+        }
+        break;
+      }
+      case "latest": {
+        if (object.requirement?.latest !== undefined && object.requirement?.latest !== null) {
+          message.requirement = { $case: "latest", latest: LatestVersion.fromPartial(object.requirement.latest) };
+        }
+        break;
+      }
+      case "pinnedHash": {
+        if (object.requirement?.pinnedHash !== undefined && object.requirement?.pinnedHash !== null) {
+          message.requirement = {
+            $case: "pinnedHash",
+            pinnedHash: PinnedHashVersion.fromPartial(object.requirement.pinnedHash),
+          };
+        }
+        break;
+      }
+    }
+    return message;
+  },
+};
+
+function createBaseExactVersion(): ExactVersion {
+  return { version: "" };
+}
+
+export const ExactVersion: MessageFns<ExactVersion> = {
+  encode(message: ExactVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ExactVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseExactVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ExactVersion {
+    return { version: isSet(object.version) ? globalThis.String(object.version) : "" };
+  },
+
+  toJSON(message: ExactVersion): unknown {
+    const obj: any = {};
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ExactVersion>, I>>(base?: I): ExactVersion {
+    return ExactVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ExactVersion>, I>>(object: I): ExactVersion {
+    const message = createBaseExactVersion();
+    message.version = object.version ?? "";
+    return message;
+  },
+};
+
+function createBaseCaretVersion(): CaretVersion {
+  return { version: "" };
+}
+
+export const CaretVersion: MessageFns<CaretVersion> = {
+  encode(message: CaretVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CaretVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCaretVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CaretVersion {
+    return { version: isSet(object.version) ? globalThis.String(object.version) : "" };
+  },
+
+  toJSON(message: CaretVersion): unknown {
+    const obj: any = {};
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CaretVersion>, I>>(base?: I): CaretVersion {
+    return CaretVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CaretVersion>, I>>(object: I): CaretVersion {
+    const message = createBaseCaretVersion();
+    message.version = object.version ?? "";
+    return message;
+  },
+};
+
+function createBaseTildeVersion(): TildeVersion {
+  return { version: "" };
+}
+
+export const TildeVersion: MessageFns<TildeVersion> = {
+  encode(message: TildeVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TildeVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTildeVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TildeVersion {
+    return { version: isSet(object.version) ? globalThis.String(object.version) : "" };
+  },
+
+  toJSON(message: TildeVersion): unknown {
+    const obj: any = {};
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TildeVersion>, I>>(base?: I): TildeVersion {
+    return TildeVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<TildeVersion>, I>>(object: I): TildeVersion {
+    const message = createBaseTildeVersion();
+    message.version = object.version ?? "";
+    return message;
+  },
+};
+
+function createBaseLatestVersion(): LatestVersion {
+  return {};
+}
+
+export const LatestVersion: MessageFns<LatestVersion> = {
+  encode(_: LatestVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): LatestVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLatestVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): LatestVersion {
+    return {};
+  },
+
+  toJSON(_: LatestVersion): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<LatestVersion>, I>>(base?: I): LatestVersion {
+    return LatestVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<LatestVersion>, I>>(_: I): LatestVersion {
+    const message = createBaseLatestVersion();
+    return message;
+  },
+};
+
+function createBasePinnedHashVersion(): PinnedHashVersion {
+  return { schemaHash: "" };
+}
+
+export const PinnedHashVersion: MessageFns<PinnedHashVersion> = {
+  encode(message: PinnedHashVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.schemaHash !== "") {
+      writer.uint32(10).string(message.schemaHash);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PinnedHashVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePinnedHashVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.schemaHash = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PinnedHashVersion {
+    return {
+      schemaHash: isSet(object.schemaHash)
+        ? globalThis.String(object.schemaHash)
+        : isSet(object.schema_hash)
+        ? globalThis.String(object.schema_hash)
+        : "",
+    };
+  },
+
+  toJSON(message: PinnedHashVersion): unknown {
+    const obj: any = {};
+    if (message.schemaHash !== "") {
+      obj.schemaHash = message.schemaHash;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PinnedHashVersion>, I>>(base?: I): PinnedHashVersion {
+    return PinnedHashVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<PinnedHashVersion>, I>>(object: I): PinnedHashVersion {
+    const message = createBasePinnedHashVersion();
+    message.schemaHash = object.schemaHash ?? "";
+    return message;
+  },
+};
+
+function createBaseSchemaRef(): SchemaRef {
+  return { name: "", version: undefined };
+}
+
+export const SchemaRef: MessageFns<SchemaRef> = {
+  encode(message: SchemaRef, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.version !== undefined) {
+      VersionReq.encode(message.version, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SchemaRef {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSchemaRef();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.version = VersionReq.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SchemaRef {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      version: isSet(object.version) ? VersionReq.fromJSON(object.version) : undefined,
+    };
+  },
+
+  toJSON(message: SchemaRef): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.version !== undefined) {
+      obj.version = VersionReq.toJSON(message.version);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SchemaRef>, I>>(base?: I): SchemaRef {
+    return SchemaRef.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SchemaRef>, I>>(object: I): SchemaRef {
+    const message = createBaseSchemaRef();
+    message.name = object.name ?? "";
+    message.version = (object.version !== undefined && object.version !== null)
+      ? VersionReq.fromPartial(object.version)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseFieldShape(): FieldShape {
+  return { name: "", number: 0, typeName: "", repeated: false, optional: false };
+}
+
+export const FieldShape: MessageFns<FieldShape> = {
+  encode(message: FieldShape, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.number !== 0) {
+      writer.uint32(16).int32(message.number);
+    }
+    if (message.typeName !== "") {
+      writer.uint32(26).string(message.typeName);
+    }
+    if (message.repeated !== false) {
+      writer.uint32(32).bool(message.repeated);
+    }
+    if (message.optional !== false) {
+      writer.uint32(40).bool(message.optional);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): FieldShape {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFieldShape();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.number = reader.int32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.typeName = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.repeated = reader.bool();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.optional = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FieldShape {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      number: isSet(object.number) ? globalThis.Number(object.number) : 0,
+      typeName: isSet(object.typeName)
+        ? globalThis.String(object.typeName)
+        : isSet(object.type_name)
+        ? globalThis.String(object.type_name)
+        : "",
+      repeated: isSet(object.repeated) ? globalThis.Boolean(object.repeated) : false,
+      optional: isSet(object.optional) ? globalThis.Boolean(object.optional) : false,
+    };
+  },
+
+  toJSON(message: FieldShape): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.number !== 0) {
+      obj.number = Math.round(message.number);
+    }
+    if (message.typeName !== "") {
+      obj.typeName = message.typeName;
+    }
+    if (message.repeated !== false) {
+      obj.repeated = message.repeated;
+    }
+    if (message.optional !== false) {
+      obj.optional = message.optional;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FieldShape>, I>>(base?: I): FieldShape {
+    return FieldShape.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<FieldShape>, I>>(object: I): FieldShape {
+    const message = createBaseFieldShape();
+    message.name = object.name ?? "";
+    message.number = object.number ?? 0;
+    message.typeName = object.typeName ?? "";
+    message.repeated = object.repeated ?? false;
+    message.optional = object.optional ?? false;
+    return message;
+  },
+};
+
+function createBaseMessageShape(): MessageShape {
+  return { typeName: "", fields: [] };
+}
+
+export const MessageShape: MessageFns<MessageShape> = {
+  encode(message: MessageShape, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.typeName !== "") {
+      writer.uint32(10).string(message.typeName);
+    }
+    for (const v of message.fields) {
+      FieldShape.encode(v!, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): MessageShape {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageShape();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.typeName = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.fields.push(FieldShape.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageShape {
+    return {
+      typeName: isSet(object.typeName)
+        ? globalThis.String(object.typeName)
+        : isSet(object.type_name)
+        ? globalThis.String(object.type_name)
+        : "",
+      fields: globalThis.Array.isArray(object?.fields) ? object.fields.map((e: any) => FieldShape.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: MessageShape): unknown {
+    const obj: any = {};
+    if (message.typeName !== "") {
+      obj.typeName = message.typeName;
+    }
+    if (message.fields?.length) {
+      obj.fields = message.fields.map((e) => FieldShape.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageShape>, I>>(base?: I): MessageShape {
+    return MessageShape.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<MessageShape>, I>>(object: I): MessageShape {
+    const message = createBaseMessageShape();
+    message.typeName = object.typeName ?? "";
+    message.fields = object.fields?.map((e) => FieldShape.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseSchemaShape(): SchemaShape {
+  return { stateMessage: undefined, commands: {} };
+}
+
+export const SchemaShape: MessageFns<SchemaShape> = {
+  encode(message: SchemaShape, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.stateMessage !== undefined) {
+      MessageShape.encode(message.stateMessage, writer.uint32(10).fork()).join();
+    }
+    globalThis.Object.entries(message.commands).forEach(([key, value]: [string, MessageShape]) => {
+      SchemaShape_CommandsEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SchemaShape {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSchemaShape();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.stateMessage = MessageShape.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          const entry2 = SchemaShape_CommandsEntry.decode(reader, reader.uint32());
+          if (entry2.value !== undefined) {
+            message.commands[entry2.key] = entry2.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SchemaShape {
+    return {
+      stateMessage: isSet(object.stateMessage)
+        ? MessageShape.fromJSON(object.stateMessage)
+        : isSet(object.state_message)
+        ? MessageShape.fromJSON(object.state_message)
+        : undefined,
+      commands: isObject(object.commands)
+        ? (globalThis.Object.entries(object.commands) as [string, any][]).reduce(
+          (acc: { [key: string]: MessageShape }, [key, value]: [string, any]) => {
+            acc[key] = MessageShape.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+    };
+  },
+
+  toJSON(message: SchemaShape): unknown {
+    const obj: any = {};
+    if (message.stateMessage !== undefined) {
+      obj.stateMessage = MessageShape.toJSON(message.stateMessage);
+    }
+    if (message.commands) {
+      const entries = globalThis.Object.entries(message.commands) as [string, MessageShape][];
+      if (entries.length > 0) {
+        obj.commands = {};
+        entries.forEach(([k, v]) => {
+          obj.commands[k] = MessageShape.toJSON(v);
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SchemaShape>, I>>(base?: I): SchemaShape {
+    return SchemaShape.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SchemaShape>, I>>(object: I): SchemaShape {
+    const message = createBaseSchemaShape();
+    message.stateMessage = (object.stateMessage !== undefined && object.stateMessage !== null)
+      ? MessageShape.fromPartial(object.stateMessage)
+      : undefined;
+    message.commands = (globalThis.Object.entries(object.commands ?? {}) as [string, MessageShape][]).reduce(
+      (acc: { [key: string]: MessageShape }, [key, value]: [string, MessageShape]) => {
+        if (value !== undefined) {
+          acc[key] = MessageShape.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBaseSchemaShape_CommandsEntry(): SchemaShape_CommandsEntry {
+  return { key: "", value: undefined };
+}
+
+export const SchemaShape_CommandsEntry: MessageFns<SchemaShape_CommandsEntry> = {
+  encode(message: SchemaShape_CommandsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      MessageShape.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SchemaShape_CommandsEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSchemaShape_CommandsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = MessageShape.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SchemaShape_CommandsEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? MessageShape.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: SchemaShape_CommandsEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = MessageShape.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SchemaShape_CommandsEntry>, I>>(base?: I): SchemaShape_CommandsEntry {
+    return SchemaShape_CommandsEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SchemaShape_CommandsEntry>, I>>(object: I): SchemaShape_CommandsEntry {
+    const message = createBaseSchemaShape_CommandsEntry();
+    message.key = object.key ?? "";
+    message.value = (object.value !== undefined && object.value !== null)
+      ? MessageShape.fromPartial(object.value)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSchemaBinding(): SchemaBinding {
+  return { name: "", version: "", schemaHash: "", logicHash: "" };
+}
+
+export const SchemaBinding: MessageFns<SchemaBinding> = {
+  encode(message: SchemaBinding, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.version !== "") {
+      writer.uint32(18).string(message.version);
+    }
+    if (message.schemaHash !== "") {
+      writer.uint32(26).string(message.schemaHash);
+    }
+    if (message.logicHash !== "") {
+      writer.uint32(34).string(message.logicHash);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SchemaBinding {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSchemaBinding();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.schemaHash = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.logicHash = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SchemaBinding {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      version: isSet(object.version) ? globalThis.String(object.version) : "",
+      schemaHash: isSet(object.schemaHash)
+        ? globalThis.String(object.schemaHash)
+        : isSet(object.schema_hash)
+        ? globalThis.String(object.schema_hash)
+        : "",
+      logicHash: isSet(object.logicHash)
+        ? globalThis.String(object.logicHash)
+        : isSet(object.logic_hash)
+        ? globalThis.String(object.logic_hash)
+        : "",
+    };
+  },
+
+  toJSON(message: SchemaBinding): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    if (message.schemaHash !== "") {
+      obj.schemaHash = message.schemaHash;
+    }
+    if (message.logicHash !== "") {
+      obj.logicHash = message.logicHash;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SchemaBinding>, I>>(base?: I): SchemaBinding {
+    return SchemaBinding.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SchemaBinding>, I>>(object: I): SchemaBinding {
+    const message = createBaseSchemaBinding();
+    message.name = object.name ?? "";
+    message.version = object.version ?? "";
+    message.schemaHash = object.schemaHash ?? "";
+    message.logicHash = object.logicHash ?? "";
+    return message;
+  },
+};
+
+function createBaseRegisteredVersion(): RegisteredVersion {
+  return {
+    version: "",
+    schemaHash: "",
+    logicHash: "",
+    schemaShape: undefined,
+    status: RegistryStatus.REGISTRY_STATUS_UNSPECIFIED,
+    registeredAt: 0,
+    strict: false,
+  };
+}
+
+export const RegisteredVersion: MessageFns<RegisteredVersion> = {
+  encode(message: RegisteredVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    if (message.schemaHash !== "") {
+      writer.uint32(18).string(message.schemaHash);
+    }
+    if (message.logicHash !== "") {
+      writer.uint32(26).string(message.logicHash);
+    }
+    if (message.schemaShape !== undefined) {
+      SchemaShape.encode(message.schemaShape, writer.uint32(34).fork()).join();
+    }
+    if (message.status !== RegistryStatus.REGISTRY_STATUS_UNSPECIFIED) {
+      writer.uint32(40).int32(registryStatusToNumber(message.status));
+    }
+    if (message.registeredAt !== 0) {
+      writer.uint32(48).int64(message.registeredAt);
+    }
+    if (message.strict !== false) {
+      writer.uint32(56).bool(message.strict);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegisteredVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegisteredVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.schemaHash = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.logicHash = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.schemaShape = SchemaShape.decode(reader, reader.uint32());
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.status = registryStatusFromJSON(reader.int32());
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.registeredAt = longToNumber(reader.int64());
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.strict = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegisteredVersion {
+    return {
+      version: isSet(object.version) ? globalThis.String(object.version) : "",
+      schemaHash: isSet(object.schemaHash)
+        ? globalThis.String(object.schemaHash)
+        : isSet(object.schema_hash)
+        ? globalThis.String(object.schema_hash)
+        : "",
+      logicHash: isSet(object.logicHash)
+        ? globalThis.String(object.logicHash)
+        : isSet(object.logic_hash)
+        ? globalThis.String(object.logic_hash)
+        : "",
+      schemaShape: isSet(object.schemaShape)
+        ? SchemaShape.fromJSON(object.schemaShape)
+        : isSet(object.schema_shape)
+        ? SchemaShape.fromJSON(object.schema_shape)
+        : undefined,
+      status: isSet(object.status) ? registryStatusFromJSON(object.status) : RegistryStatus.REGISTRY_STATUS_UNSPECIFIED,
+      registeredAt: isSet(object.registeredAt)
+        ? globalThis.Number(object.registeredAt)
+        : isSet(object.registered_at)
+        ? globalThis.Number(object.registered_at)
+        : 0,
+      strict: isSet(object.strict) ? globalThis.Boolean(object.strict) : false,
+    };
+  },
+
+  toJSON(message: RegisteredVersion): unknown {
+    const obj: any = {};
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    if (message.schemaHash !== "") {
+      obj.schemaHash = message.schemaHash;
+    }
+    if (message.logicHash !== "") {
+      obj.logicHash = message.logicHash;
+    }
+    if (message.schemaShape !== undefined) {
+      obj.schemaShape = SchemaShape.toJSON(message.schemaShape);
+    }
+    if (message.status !== RegistryStatus.REGISTRY_STATUS_UNSPECIFIED) {
+      obj.status = registryStatusToJSON(message.status);
+    }
+    if (message.registeredAt !== 0) {
+      obj.registeredAt = Math.round(message.registeredAt);
+    }
+    if (message.strict !== false) {
+      obj.strict = message.strict;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegisteredVersion>, I>>(base?: I): RegisteredVersion {
+    return RegisteredVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegisteredVersion>, I>>(object: I): RegisteredVersion {
+    const message = createBaseRegisteredVersion();
+    message.version = object.version ?? "";
+    message.schemaHash = object.schemaHash ?? "";
+    message.logicHash = object.logicHash ?? "";
+    message.schemaShape = (object.schemaShape !== undefined && object.schemaShape !== null)
+      ? SchemaShape.fromPartial(object.schemaShape)
+      : undefined;
+    message.status = object.status ?? RegistryStatus.REGISTRY_STATUS_UNSPECIFIED;
+    message.registeredAt = object.registeredAt ?? 0;
+    message.strict = object.strict ?? false;
+    return message;
+  },
+};
+
+function createBaseVersionLineage(): VersionLineage {
+  return { versions: {} };
+}
+
+export const VersionLineage: MessageFns<VersionLineage> = {
+  encode(message: VersionLineage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    globalThis.Object.entries(message.versions).forEach(([key, value]: [string, RegisteredVersion]) => {
+      VersionLineage_VersionsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VersionLineage {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVersionLineage();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          const entry1 = VersionLineage_VersionsEntry.decode(reader, reader.uint32());
+          if (entry1.value !== undefined) {
+            message.versions[entry1.key] = entry1.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): VersionLineage {
+    return {
+      versions: isObject(object.versions)
+        ? (globalThis.Object.entries(object.versions) as [string, any][]).reduce(
+          (acc: { [key: string]: RegisteredVersion }, [key, value]: [string, any]) => {
+            acc[key] = RegisteredVersion.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+    };
+  },
+
+  toJSON(message: VersionLineage): unknown {
+    const obj: any = {};
+    if (message.versions) {
+      const entries = globalThis.Object.entries(message.versions) as [string, RegisteredVersion][];
+      if (entries.length > 0) {
+        obj.versions = {};
+        entries.forEach(([k, v]) => {
+          obj.versions[k] = RegisteredVersion.toJSON(v);
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<VersionLineage>, I>>(base?: I): VersionLineage {
+    return VersionLineage.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<VersionLineage>, I>>(object: I): VersionLineage {
+    const message = createBaseVersionLineage();
+    message.versions = (globalThis.Object.entries(object.versions ?? {}) as [string, RegisteredVersion][]).reduce(
+      (acc: { [key: string]: RegisteredVersion }, [key, value]: [string, RegisteredVersion]) => {
+        if (value !== undefined) {
+          acc[key] = RegisteredVersion.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBaseVersionLineage_VersionsEntry(): VersionLineage_VersionsEntry {
+  return { key: "", value: undefined };
+}
+
+export const VersionLineage_VersionsEntry: MessageFns<VersionLineage_VersionsEntry> = {
+  encode(message: VersionLineage_VersionsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      RegisteredVersion.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VersionLineage_VersionsEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVersionLineage_VersionsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = RegisteredVersion.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): VersionLineage_VersionsEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? RegisteredVersion.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: VersionLineage_VersionsEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = RegisteredVersion.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<VersionLineage_VersionsEntry>, I>>(base?: I): VersionLineage_VersionsEntry {
+    return VersionLineage_VersionsEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<VersionLineage_VersionsEntry>, I>>(object: I): VersionLineage_VersionsEntry {
+    const message = createBaseVersionLineage_VersionsEntry();
+    message.key = object.key ?? "";
+    message.value = (object.value !== undefined && object.value !== null)
+      ? RegisteredVersion.fromPartial(object.value)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseRegistryTarget(): RegistryTarget {
+  return { target: undefined };
+}
+
+export const RegistryTarget: MessageFns<RegistryTarget> = {
+  encode(message: RegistryTarget, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    switch (message.target?.$case) {
+      case "schemaPackage":
+        SchemaPackageTarget.encode(message.target.schemaPackage, writer.uint32(10).fork()).join();
+        break;
+      case "instanceAlias":
+        InstanceAliasTarget.encode(message.target.instanceAlias, writer.uint32(18).fork()).join();
+        break;
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegistryTarget {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegistryTarget();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.target = {
+            $case: "schemaPackage",
+            schemaPackage: SchemaPackageTarget.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.target = {
+            $case: "instanceAlias",
+            instanceAlias: InstanceAliasTarget.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegistryTarget {
+    return {
+      target: isSet(object.schemaPackage)
+        ? { $case: "schemaPackage", schemaPackage: SchemaPackageTarget.fromJSON(object.schemaPackage) }
+        : isSet(object.schema_package)
+        ? { $case: "schemaPackage", schemaPackage: SchemaPackageTarget.fromJSON(object.schema_package) }
+        : isSet(object.instanceAlias)
+        ? { $case: "instanceAlias", instanceAlias: InstanceAliasTarget.fromJSON(object.instanceAlias) }
+        : isSet(object.instance_alias)
+        ? { $case: "instanceAlias", instanceAlias: InstanceAliasTarget.fromJSON(object.instance_alias) }
+        : undefined,
+    };
+  },
+
+  toJSON(message: RegistryTarget): unknown {
+    const obj: any = {};
+    if (message.target?.$case === "schemaPackage") {
+      obj.schemaPackage = SchemaPackageTarget.toJSON(message.target.schemaPackage);
+    } else if (message.target?.$case === "instanceAlias") {
+      obj.instanceAlias = InstanceAliasTarget.toJSON(message.target.instanceAlias);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegistryTarget>, I>>(base?: I): RegistryTarget {
+    return RegistryTarget.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegistryTarget>, I>>(object: I): RegistryTarget {
+    const message = createBaseRegistryTarget();
+    switch (object.target?.$case) {
+      case "schemaPackage": {
+        if (object.target?.schemaPackage !== undefined && object.target?.schemaPackage !== null) {
+          message.target = {
+            $case: "schemaPackage",
+            schemaPackage: SchemaPackageTarget.fromPartial(object.target.schemaPackage),
+          };
+        }
+        break;
+      }
+      case "instanceAlias": {
+        if (object.target?.instanceAlias !== undefined && object.target?.instanceAlias !== null) {
+          message.target = {
+            $case: "instanceAlias",
+            instanceAlias: InstanceAliasTarget.fromPartial(object.target.instanceAlias),
+          };
+        }
+        break;
+      }
+    }
+    return message;
+  },
+};
+
+function createBaseSchemaPackageTarget(): SchemaPackageTarget {
+  return { versions: undefined };
+}
+
+export const SchemaPackageTarget: MessageFns<SchemaPackageTarget> = {
+  encode(message: SchemaPackageTarget, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.versions !== undefined) {
+      VersionLineage.encode(message.versions, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SchemaPackageTarget {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSchemaPackageTarget();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.versions = VersionLineage.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SchemaPackageTarget {
+    return { versions: isSet(object.versions) ? VersionLineage.fromJSON(object.versions) : undefined };
+  },
+
+  toJSON(message: SchemaPackageTarget): unknown {
+    const obj: any = {};
+    if (message.versions !== undefined) {
+      obj.versions = VersionLineage.toJSON(message.versions);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SchemaPackageTarget>, I>>(base?: I): SchemaPackageTarget {
+    return SchemaPackageTarget.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SchemaPackageTarget>, I>>(object: I): SchemaPackageTarget {
+    const message = createBaseSchemaPackageTarget();
+    message.versions = (object.versions !== undefined && object.versions !== null)
+      ? VersionLineage.fromPartial(object.versions)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseInstanceAliasTarget(): InstanceAliasTarget {
+  return { fiberId: "" };
+}
+
+export const InstanceAliasTarget: MessageFns<InstanceAliasTarget> = {
+  encode(message: InstanceAliasTarget, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.fiberId !== "") {
+      writer.uint32(10).string(message.fiberId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): InstanceAliasTarget {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseInstanceAliasTarget();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.fiberId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): InstanceAliasTarget {
+    return {
+      fiberId: isSet(object.fiberId)
+        ? globalThis.String(object.fiberId)
+        : isSet(object.fiber_id)
+        ? globalThis.String(object.fiber_id)
+        : "",
+    };
+  },
+
+  toJSON(message: InstanceAliasTarget): unknown {
+    const obj: any = {};
+    if (message.fiberId !== "") {
+      obj.fiberId = message.fiberId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<InstanceAliasTarget>, I>>(base?: I): InstanceAliasTarget {
+    return InstanceAliasTarget.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<InstanceAliasTarget>, I>>(object: I): InstanceAliasTarget {
+    const message = createBaseInstanceAliasTarget();
+    message.fiberId = object.fiberId ?? "";
+    return message;
+  },
+};
+
+function createBaseRegistryEntry(): RegistryEntry {
+  return { name: "", owner: [], target: undefined, metadata: {} };
+}
+
+export const RegistryEntry: MessageFns<RegistryEntry> = {
+  encode(message: RegistryEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    for (const v of message.owner) {
+      writer.uint32(18).string(v!);
+    }
+    if (message.target !== undefined) {
+      RegistryTarget.encode(message.target, writer.uint32(26).fork()).join();
+    }
+    globalThis.Object.entries(message.metadata).forEach(([key, value]: [string, string]) => {
+      RegistryEntry_MetadataEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegistryEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegistryEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.owner.push(reader.string());
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.target = RegistryTarget.decode(reader, reader.uint32());
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          const entry4 = RegistryEntry_MetadataEntry.decode(reader, reader.uint32());
+          if (entry4.value !== undefined) {
+            message.metadata[entry4.key] = entry4.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegistryEntry {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      owner: globalThis.Array.isArray(object?.owner) ? object.owner.map((e: any) => globalThis.String(e)) : [],
+      target: isSet(object.target) ? RegistryTarget.fromJSON(object.target) : undefined,
+      metadata: isObject(object.metadata)
+        ? (globalThis.Object.entries(object.metadata) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+    };
+  },
+
+  toJSON(message: RegistryEntry): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.owner?.length) {
+      obj.owner = message.owner;
+    }
+    if (message.target !== undefined) {
+      obj.target = RegistryTarget.toJSON(message.target);
+    }
+    if (message.metadata) {
+      const entries = globalThis.Object.entries(message.metadata) as [string, string][];
+      if (entries.length > 0) {
+        obj.metadata = {};
+        entries.forEach(([k, v]) => {
+          obj.metadata[k] = v;
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegistryEntry>, I>>(base?: I): RegistryEntry {
+    return RegistryEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegistryEntry>, I>>(object: I): RegistryEntry {
+    const message = createBaseRegistryEntry();
+    message.name = object.name ?? "";
+    message.owner = object.owner?.map((e) => e) || [];
+    message.target = (object.target !== undefined && object.target !== null)
+      ? RegistryTarget.fromPartial(object.target)
+      : undefined;
+    message.metadata = (globalThis.Object.entries(object.metadata ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBaseRegistryEntry_MetadataEntry(): RegistryEntry_MetadataEntry {
+  return { key: "", value: "" };
+}
+
+export const RegistryEntry_MetadataEntry: MessageFns<RegistryEntry_MetadataEntry> = {
+  encode(message: RegistryEntry_MetadataEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegistryEntry_MetadataEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegistryEntry_MetadataEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegistryEntry_MetadataEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? globalThis.String(object.value) : "",
+    };
+  },
+
+  toJSON(message: RegistryEntry_MetadataEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegistryEntry_MetadataEntry>, I>>(base?: I): RegistryEntry_MetadataEntry {
+    return RegistryEntry_MetadataEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegistryEntry_MetadataEntry>, I>>(object: I): RegistryEntry_MetadataEntry {
+    const message = createBaseRegistryEntry_MetadataEntry();
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
+    return message;
+  },
+};
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends { $case: string } ? { [K in keyof Omit<T, "$case">]?: DeepPartial<T[K]> } & { $case: T["$case"] }
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function longToNumber(int64: { toString(): string }): number {
+  const num = globalThis.Number(int64.toString());
+  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+  }
+  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
+    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+  }
+  return num;
+}
+
+function isObject(value: any): boolean {
+  return typeof value === "object" && value !== null;
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}

--- a/src/generated/ottochain/v1/fiber.ts
+++ b/src/generated/ottochain/v1/fiber.ts
@@ -7,6 +7,7 @@
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import { Struct, Value } from "../../google/protobuf/struct.js";
+import { SchemaBinding } from "./common.js";
 
 export const protobufPackage = "ottochain.v1";
 
@@ -143,12 +144,38 @@ export interface ScriptInvocation {
   invokedBy: string;
 }
 
-/** Fiber log entry - union of event receipt or script invocation */
+/** Creation receipt - birth record for a fiber, emitted once at creation (#26/#30) */
+export interface CreationReceipt {
+  fiberId: string;
+  /** Snapshot ordinal */
+  ordinal: number;
+  /** State ID */
+  initialState: string;
+  /** DAG addresses */
+  owners: string[];
+  schemaBinding?: SchemaBinding | undefined;
+  parentFiberId?: string | undefined;
+}
+
+/** Upgrade receipt - emitted when a fiber is upgraded to a different registered version (#27) */
+export interface UpgradeReceipt {
+  fiberId: string;
+  /** Snapshot ordinal */
+  ordinal: number;
+  fromBinding?: SchemaBinding | undefined;
+  toBinding?: SchemaBinding | undefined;
+  gasUsed: number;
+  migrated: boolean;
+}
+
+/** Fiber log entry - union of event receipt, script invocation, or lifecycle receipt */
 export interface FiberLogEntry {
-  entry?: { $case: "eventReceipt"; eventReceipt: EventReceipt } | {
-    $case: "scriptInvocation";
-    scriptInvocation: ScriptInvocation;
-  } | undefined;
+  entry?:
+    | { $case: "eventReceipt"; eventReceipt: EventReceipt }
+    | { $case: "scriptInvocation"; scriptInvocation: ScriptInvocation }
+    | { $case: "creationReceipt"; creationReceipt: CreationReceipt }
+    | { $case: "upgradeReceipt"; upgradeReceipt: UpgradeReceipt }
+    | undefined;
 }
 
 function createBaseAccessControlPolicy(): AccessControlPolicy {
@@ -1100,6 +1127,324 @@ export const ScriptInvocation: MessageFns<ScriptInvocation> = {
   },
 };
 
+function createBaseCreationReceipt(): CreationReceipt {
+  return { fiberId: "", ordinal: 0, initialState: "", owners: [], schemaBinding: undefined, parentFiberId: undefined };
+}
+
+export const CreationReceipt: MessageFns<CreationReceipt> = {
+  encode(message: CreationReceipt, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.fiberId !== "") {
+      writer.uint32(10).string(message.fiberId);
+    }
+    if (message.ordinal !== 0) {
+      writer.uint32(16).int64(message.ordinal);
+    }
+    if (message.initialState !== "") {
+      writer.uint32(26).string(message.initialState);
+    }
+    for (const v of message.owners) {
+      writer.uint32(34).string(v!);
+    }
+    if (message.schemaBinding !== undefined) {
+      SchemaBinding.encode(message.schemaBinding, writer.uint32(42).fork()).join();
+    }
+    if (message.parentFiberId !== undefined) {
+      writer.uint32(50).string(message.parentFiberId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CreationReceipt {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCreationReceipt();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.fiberId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.ordinal = longToNumber(reader.int64());
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.initialState = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.owners.push(reader.string());
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.schemaBinding = SchemaBinding.decode(reader, reader.uint32());
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.parentFiberId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CreationReceipt {
+    return {
+      fiberId: isSet(object.fiberId)
+        ? globalThis.String(object.fiberId)
+        : isSet(object.fiber_id)
+        ? globalThis.String(object.fiber_id)
+        : "",
+      ordinal: isSet(object.ordinal) ? globalThis.Number(object.ordinal) : 0,
+      initialState: isSet(object.initialState)
+        ? globalThis.String(object.initialState)
+        : isSet(object.initial_state)
+        ? globalThis.String(object.initial_state)
+        : "",
+      owners: globalThis.Array.isArray(object?.owners) ? object.owners.map((e: any) => globalThis.String(e)) : [],
+      schemaBinding: isSet(object.schemaBinding)
+        ? SchemaBinding.fromJSON(object.schemaBinding)
+        : isSet(object.schema_binding)
+        ? SchemaBinding.fromJSON(object.schema_binding)
+        : undefined,
+      parentFiberId: isSet(object.parentFiberId)
+        ? globalThis.String(object.parentFiberId)
+        : isSet(object.parent_fiber_id)
+        ? globalThis.String(object.parent_fiber_id)
+        : undefined,
+    };
+  },
+
+  toJSON(message: CreationReceipt): unknown {
+    const obj: any = {};
+    if (message.fiberId !== "") {
+      obj.fiberId = message.fiberId;
+    }
+    if (message.ordinal !== 0) {
+      obj.ordinal = Math.round(message.ordinal);
+    }
+    if (message.initialState !== "") {
+      obj.initialState = message.initialState;
+    }
+    if (message.owners?.length) {
+      obj.owners = message.owners;
+    }
+    if (message.schemaBinding !== undefined) {
+      obj.schemaBinding = SchemaBinding.toJSON(message.schemaBinding);
+    }
+    if (message.parentFiberId !== undefined) {
+      obj.parentFiberId = message.parentFiberId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CreationReceipt>, I>>(base?: I): CreationReceipt {
+    return CreationReceipt.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CreationReceipt>, I>>(object: I): CreationReceipt {
+    const message = createBaseCreationReceipt();
+    message.fiberId = object.fiberId ?? "";
+    message.ordinal = object.ordinal ?? 0;
+    message.initialState = object.initialState ?? "";
+    message.owners = object.owners?.map((e) => e) || [];
+    message.schemaBinding = (object.schemaBinding !== undefined && object.schemaBinding !== null)
+      ? SchemaBinding.fromPartial(object.schemaBinding)
+      : undefined;
+    message.parentFiberId = object.parentFiberId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseUpgradeReceipt(): UpgradeReceipt {
+  return { fiberId: "", ordinal: 0, fromBinding: undefined, toBinding: undefined, gasUsed: 0, migrated: false };
+}
+
+export const UpgradeReceipt: MessageFns<UpgradeReceipt> = {
+  encode(message: UpgradeReceipt, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.fiberId !== "") {
+      writer.uint32(10).string(message.fiberId);
+    }
+    if (message.ordinal !== 0) {
+      writer.uint32(16).int64(message.ordinal);
+    }
+    if (message.fromBinding !== undefined) {
+      SchemaBinding.encode(message.fromBinding, writer.uint32(26).fork()).join();
+    }
+    if (message.toBinding !== undefined) {
+      SchemaBinding.encode(message.toBinding, writer.uint32(34).fork()).join();
+    }
+    if (message.gasUsed !== 0) {
+      writer.uint32(40).int64(message.gasUsed);
+    }
+    if (message.migrated !== false) {
+      writer.uint32(48).bool(message.migrated);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpgradeReceipt {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpgradeReceipt();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.fiberId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.ordinal = longToNumber(reader.int64());
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.fromBinding = SchemaBinding.decode(reader, reader.uint32());
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.toBinding = SchemaBinding.decode(reader, reader.uint32());
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.gasUsed = longToNumber(reader.int64());
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.migrated = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpgradeReceipt {
+    return {
+      fiberId: isSet(object.fiberId)
+        ? globalThis.String(object.fiberId)
+        : isSet(object.fiber_id)
+        ? globalThis.String(object.fiber_id)
+        : "",
+      ordinal: isSet(object.ordinal) ? globalThis.Number(object.ordinal) : 0,
+      fromBinding: isSet(object.fromBinding)
+        ? SchemaBinding.fromJSON(object.fromBinding)
+        : isSet(object.from_binding)
+        ? SchemaBinding.fromJSON(object.from_binding)
+        : undefined,
+      toBinding: isSet(object.toBinding)
+        ? SchemaBinding.fromJSON(object.toBinding)
+        : isSet(object.to_binding)
+        ? SchemaBinding.fromJSON(object.to_binding)
+        : undefined,
+      gasUsed: isSet(object.gasUsed)
+        ? globalThis.Number(object.gasUsed)
+        : isSet(object.gas_used)
+        ? globalThis.Number(object.gas_used)
+        : 0,
+      migrated: isSet(object.migrated) ? globalThis.Boolean(object.migrated) : false,
+    };
+  },
+
+  toJSON(message: UpgradeReceipt): unknown {
+    const obj: any = {};
+    if (message.fiberId !== "") {
+      obj.fiberId = message.fiberId;
+    }
+    if (message.ordinal !== 0) {
+      obj.ordinal = Math.round(message.ordinal);
+    }
+    if (message.fromBinding !== undefined) {
+      obj.fromBinding = SchemaBinding.toJSON(message.fromBinding);
+    }
+    if (message.toBinding !== undefined) {
+      obj.toBinding = SchemaBinding.toJSON(message.toBinding);
+    }
+    if (message.gasUsed !== 0) {
+      obj.gasUsed = Math.round(message.gasUsed);
+    }
+    if (message.migrated !== false) {
+      obj.migrated = message.migrated;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpgradeReceipt>, I>>(base?: I): UpgradeReceipt {
+    return UpgradeReceipt.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpgradeReceipt>, I>>(object: I): UpgradeReceipt {
+    const message = createBaseUpgradeReceipt();
+    message.fiberId = object.fiberId ?? "";
+    message.ordinal = object.ordinal ?? 0;
+    message.fromBinding = (object.fromBinding !== undefined && object.fromBinding !== null)
+      ? SchemaBinding.fromPartial(object.fromBinding)
+      : undefined;
+    message.toBinding = (object.toBinding !== undefined && object.toBinding !== null)
+      ? SchemaBinding.fromPartial(object.toBinding)
+      : undefined;
+    message.gasUsed = object.gasUsed ?? 0;
+    message.migrated = object.migrated ?? false;
+    return message;
+  },
+};
+
 function createBaseFiberLogEntry(): FiberLogEntry {
   return { entry: undefined };
 }
@@ -1112,6 +1457,12 @@ export const FiberLogEntry: MessageFns<FiberLogEntry> = {
         break;
       case "scriptInvocation":
         ScriptInvocation.encode(message.entry.scriptInvocation, writer.uint32(18).fork()).join();
+        break;
+      case "creationReceipt":
+        CreationReceipt.encode(message.entry.creationReceipt, writer.uint32(26).fork()).join();
+        break;
+      case "upgradeReceipt":
+        UpgradeReceipt.encode(message.entry.upgradeReceipt, writer.uint32(34).fork()).join();
         break;
     }
     return writer;
@@ -1143,6 +1494,25 @@ export const FiberLogEntry: MessageFns<FiberLogEntry> = {
           };
           continue;
         }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.entry = {
+            $case: "creationReceipt",
+            creationReceipt: CreationReceipt.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.entry = { $case: "upgradeReceipt", upgradeReceipt: UpgradeReceipt.decode(reader, reader.uint32()) };
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1162,6 +1532,14 @@ export const FiberLogEntry: MessageFns<FiberLogEntry> = {
         ? { $case: "scriptInvocation", scriptInvocation: ScriptInvocation.fromJSON(object.scriptInvocation) }
         : isSet(object.script_invocation)
         ? { $case: "scriptInvocation", scriptInvocation: ScriptInvocation.fromJSON(object.script_invocation) }
+        : isSet(object.creationReceipt)
+        ? { $case: "creationReceipt", creationReceipt: CreationReceipt.fromJSON(object.creationReceipt) }
+        : isSet(object.creation_receipt)
+        ? { $case: "creationReceipt", creationReceipt: CreationReceipt.fromJSON(object.creation_receipt) }
+        : isSet(object.upgradeReceipt)
+        ? { $case: "upgradeReceipt", upgradeReceipt: UpgradeReceipt.fromJSON(object.upgradeReceipt) }
+        : isSet(object.upgrade_receipt)
+        ? { $case: "upgradeReceipt", upgradeReceipt: UpgradeReceipt.fromJSON(object.upgrade_receipt) }
         : undefined,
     };
   },
@@ -1172,6 +1550,10 @@ export const FiberLogEntry: MessageFns<FiberLogEntry> = {
       obj.eventReceipt = EventReceipt.toJSON(message.entry.eventReceipt);
     } else if (message.entry?.$case === "scriptInvocation") {
       obj.scriptInvocation = ScriptInvocation.toJSON(message.entry.scriptInvocation);
+    } else if (message.entry?.$case === "creationReceipt") {
+      obj.creationReceipt = CreationReceipt.toJSON(message.entry.creationReceipt);
+    } else if (message.entry?.$case === "upgradeReceipt") {
+      obj.upgradeReceipt = UpgradeReceipt.toJSON(message.entry.upgradeReceipt);
     }
     return obj;
   },
@@ -1193,6 +1575,24 @@ export const FiberLogEntry: MessageFns<FiberLogEntry> = {
           message.entry = {
             $case: "scriptInvocation",
             scriptInvocation: ScriptInvocation.fromPartial(object.entry.scriptInvocation),
+          };
+        }
+        break;
+      }
+      case "creationReceipt": {
+        if (object.entry?.creationReceipt !== undefined && object.entry?.creationReceipt !== null) {
+          message.entry = {
+            $case: "creationReceipt",
+            creationReceipt: CreationReceipt.fromPartial(object.entry.creationReceipt),
+          };
+        }
+        break;
+      }
+      case "upgradeReceipt": {
+        if (object.entry?.upgradeReceipt !== undefined && object.entry?.upgradeReceipt !== null) {
+          message.entry = {
+            $case: "upgradeReceipt",
+            upgradeReceipt: UpgradeReceipt.fromPartial(object.entry.upgradeReceipt),
           };
         }
         break;

--- a/src/generated/ottochain/v1/messages.ts
+++ b/src/generated/ottochain/v1/messages.ts
@@ -7,6 +7,14 @@
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import { Value } from "../../google/protobuf/struct.js";
+import {
+  RegistryStatus,
+  registryStatusFromJSON,
+  registryStatusToJSON,
+  registryStatusToNumber,
+  SchemaRef,
+  SchemaShape,
+} from "./common.js";
 import { AccessControlPolicy, StateMachineDefinition } from "./fiber.js";
 
 export const protobufPackage = "ottochain.v1";
@@ -16,7 +24,14 @@ export interface CreateStateMachine {
   fiberId: string;
   definition?: StateMachineDefinition | undefined;
   initialData?: any | undefined;
-  parentFiberId?: string | undefined;
+  parentFiberId?:
+    | string
+    | undefined;
+  /**
+   * Optional reference to a registered schema/program version (#26). When present, the chain
+   * resolves it against the registry at create time and records the verified SchemaBinding.
+   */
+  schemaRef?: SchemaRef | undefined;
 }
 
 /** Trigger a state machine transition */
@@ -33,6 +48,21 @@ export interface TransitionStateMachine {
 /** Archive a state machine fiber */
 export interface ArchiveStateMachine {
   fiberId: string;
+  /** Fiber ordinal */
+  targetSequenceNumber: number;
+}
+
+/** Upgrade an existing fiber to a different registered version of the SAME package (#27). */
+export interface UpgradeFiber {
+  fiberId: string;
+  targetRef?: SchemaRef | undefined;
+  newDefinition?:
+    | StateMachineDefinition
+    | undefined;
+  /** Optional JSON-Logic transform applied to the prior state data during upgrade. */
+  migration?:
+    | any
+    | undefined;
   /** Fiber ordinal */
   targetSequenceNumber: number;
 }
@@ -56,6 +86,59 @@ export interface InvokeScript {
   targetSequenceNumber: number;
 }
 
+/**
+ * Create-or-append a registry schema-package version (npm-publish semantics). The chain derives
+ * the routing id from `name`, so there is no fiber_id on the wire.
+ */
+export interface PublishVersion {
+  /** Full registry name "labels.tld" (e.g. "order.package") */
+  name: string;
+  /** SemVer string "MAJOR.MINOR.PATCH" */
+  version: string;
+  /** Base64 of the proto FileDescriptorSet (base64-validated + hashed, then dropped) */
+  schemaB64: string;
+  schemaShape?: SchemaShape | undefined;
+  definition?:
+    | StateMachineDefinition
+    | undefined;
+  /** Opt-in runtime conformance gate (#33); default false */
+  strict: boolean;
+  /** Optional off-chain links grab-bag */
+  metadata: { [key: string]: string };
+}
+
+export interface PublishVersion_MetadataEntry {
+  key: string;
+  value: string;
+}
+
+/** Change a registered version's lifecycle status (Active <-> Deprecated -> Yanked). Owner-gated. */
+export interface SetVersionStatus {
+  /** Full registry name "labels.tld" */
+  name: string;
+  /** SemVer string */
+  version: string;
+  status: RegistryStatus;
+}
+
+/**
+ * Register a human-readable nickname for an existing fiber (#29). The chain derives the routing id
+ * from `name`, so there is no fiber_id on the wire.
+ */
+export interface RegisterAlias {
+  /** Full registry name "labels.tld" (e.g. "my-escrow.machine") */
+  name: string;
+  /** The existing fiber UUID this alias points at */
+  targetFiberId: string;
+  /** Optional off-chain links grab-bag */
+  metadata: { [key: string]: string };
+}
+
+export interface RegisterAlias_MetadataEntry {
+  key: string;
+  value: string;
+}
+
 /** Union message type for all OttoChain operations */
 export interface OttochainMessage {
   message?:
@@ -64,11 +147,15 @@ export interface OttochainMessage {
     | { $case: "archiveStateMachine"; archiveStateMachine: ArchiveStateMachine }
     | { $case: "createScript"; createScript: CreateScript }
     | { $case: "invokeScript"; invokeScript: InvokeScript }
+    | { $case: "upgradeFiber"; upgradeFiber: UpgradeFiber }
+    | { $case: "publishVersion"; publishVersion: PublishVersion }
+    | { $case: "setVersionStatus"; setVersionStatus: SetVersionStatus }
+    | { $case: "registerAlias"; registerAlias: RegisterAlias }
     | undefined;
 }
 
 function createBaseCreateStateMachine(): CreateStateMachine {
-  return { fiberId: "", definition: undefined, initialData: undefined, parentFiberId: undefined };
+  return { fiberId: "", definition: undefined, initialData: undefined, parentFiberId: undefined, schemaRef: undefined };
 }
 
 export const CreateStateMachine: MessageFns<CreateStateMachine> = {
@@ -84,6 +171,9 @@ export const CreateStateMachine: MessageFns<CreateStateMachine> = {
     }
     if (message.parentFiberId !== undefined) {
       writer.uint32(34).string(message.parentFiberId);
+    }
+    if (message.schemaRef !== undefined) {
+      SchemaRef.encode(message.schemaRef, writer.uint32(42).fork()).join();
     }
     return writer;
   },
@@ -127,6 +217,14 @@ export const CreateStateMachine: MessageFns<CreateStateMachine> = {
           message.parentFiberId = reader.string();
           continue;
         }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.schemaRef = SchemaRef.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -154,6 +252,11 @@ export const CreateStateMachine: MessageFns<CreateStateMachine> = {
         : isSet(object.parent_fiber_id)
         ? globalThis.String(object.parent_fiber_id)
         : undefined,
+      schemaRef: isSet(object.schemaRef)
+        ? SchemaRef.fromJSON(object.schemaRef)
+        : isSet(object.schema_ref)
+        ? SchemaRef.fromJSON(object.schema_ref)
+        : undefined,
     };
   },
 
@@ -171,6 +274,9 @@ export const CreateStateMachine: MessageFns<CreateStateMachine> = {
     if (message.parentFiberId !== undefined) {
       obj.parentFiberId = message.parentFiberId;
     }
+    if (message.schemaRef !== undefined) {
+      obj.schemaRef = SchemaRef.toJSON(message.schemaRef);
+    }
     return obj;
   },
 
@@ -185,6 +291,9 @@ export const CreateStateMachine: MessageFns<CreateStateMachine> = {
       : undefined;
     message.initialData = object.initialData ?? undefined;
     message.parentFiberId = object.parentFiberId ?? undefined;
+    message.schemaRef = (object.schemaRef !== undefined && object.schemaRef !== null)
+      ? SchemaRef.fromPartial(object.schemaRef)
+      : undefined;
     return message;
   },
 };
@@ -388,6 +497,150 @@ export const ArchiveStateMachine: MessageFns<ArchiveStateMachine> = {
   fromPartial<I extends Exact<DeepPartial<ArchiveStateMachine>, I>>(object: I): ArchiveStateMachine {
     const message = createBaseArchiveStateMachine();
     message.fiberId = object.fiberId ?? "";
+    message.targetSequenceNumber = object.targetSequenceNumber ?? 0;
+    return message;
+  },
+};
+
+function createBaseUpgradeFiber(): UpgradeFiber {
+  return { fiberId: "", targetRef: undefined, newDefinition: undefined, migration: undefined, targetSequenceNumber: 0 };
+}
+
+export const UpgradeFiber: MessageFns<UpgradeFiber> = {
+  encode(message: UpgradeFiber, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.fiberId !== "") {
+      writer.uint32(10).string(message.fiberId);
+    }
+    if (message.targetRef !== undefined) {
+      SchemaRef.encode(message.targetRef, writer.uint32(18).fork()).join();
+    }
+    if (message.newDefinition !== undefined) {
+      StateMachineDefinition.encode(message.newDefinition, writer.uint32(26).fork()).join();
+    }
+    if (message.migration !== undefined) {
+      Value.encode(Value.wrap(message.migration), writer.uint32(34).fork()).join();
+    }
+    if (message.targetSequenceNumber !== 0) {
+      writer.uint32(40).int64(message.targetSequenceNumber);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpgradeFiber {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpgradeFiber();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.fiberId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.targetRef = SchemaRef.decode(reader, reader.uint32());
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.newDefinition = StateMachineDefinition.decode(reader, reader.uint32());
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.migration = Value.unwrap(Value.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.targetSequenceNumber = longToNumber(reader.int64());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpgradeFiber {
+    return {
+      fiberId: isSet(object.fiberId)
+        ? globalThis.String(object.fiberId)
+        : isSet(object.fiber_id)
+        ? globalThis.String(object.fiber_id)
+        : "",
+      targetRef: isSet(object.targetRef)
+        ? SchemaRef.fromJSON(object.targetRef)
+        : isSet(object.target_ref)
+        ? SchemaRef.fromJSON(object.target_ref)
+        : undefined,
+      newDefinition: isSet(object.newDefinition)
+        ? StateMachineDefinition.fromJSON(object.newDefinition)
+        : isSet(object.new_definition)
+        ? StateMachineDefinition.fromJSON(object.new_definition)
+        : undefined,
+      migration: isSet(object?.migration) ? object.migration : undefined,
+      targetSequenceNumber: isSet(object.targetSequenceNumber)
+        ? globalThis.Number(object.targetSequenceNumber)
+        : isSet(object.target_sequence_number)
+        ? globalThis.Number(object.target_sequence_number)
+        : 0,
+    };
+  },
+
+  toJSON(message: UpgradeFiber): unknown {
+    const obj: any = {};
+    if (message.fiberId !== "") {
+      obj.fiberId = message.fiberId;
+    }
+    if (message.targetRef !== undefined) {
+      obj.targetRef = SchemaRef.toJSON(message.targetRef);
+    }
+    if (message.newDefinition !== undefined) {
+      obj.newDefinition = StateMachineDefinition.toJSON(message.newDefinition);
+    }
+    if (message.migration !== undefined) {
+      obj.migration = message.migration;
+    }
+    if (message.targetSequenceNumber !== 0) {
+      obj.targetSequenceNumber = Math.round(message.targetSequenceNumber);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpgradeFiber>, I>>(base?: I): UpgradeFiber {
+    return UpgradeFiber.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpgradeFiber>, I>>(object: I): UpgradeFiber {
+    const message = createBaseUpgradeFiber();
+    message.fiberId = object.fiberId ?? "";
+    message.targetRef = (object.targetRef !== undefined && object.targetRef !== null)
+      ? SchemaRef.fromPartial(object.targetRef)
+      : undefined;
+    message.newDefinition = (object.newDefinition !== undefined && object.newDefinition !== null)
+      ? StateMachineDefinition.fromPartial(object.newDefinition)
+      : undefined;
+    message.migration = object.migration ?? undefined;
     message.targetSequenceNumber = object.targetSequenceNumber ?? 0;
     return message;
   },
@@ -635,6 +888,572 @@ export const InvokeScript: MessageFns<InvokeScript> = {
   },
 };
 
+function createBasePublishVersion(): PublishVersion {
+  return {
+    name: "",
+    version: "",
+    schemaB64: "",
+    schemaShape: undefined,
+    definition: undefined,
+    strict: false,
+    metadata: {},
+  };
+}
+
+export const PublishVersion: MessageFns<PublishVersion> = {
+  encode(message: PublishVersion, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.version !== "") {
+      writer.uint32(18).string(message.version);
+    }
+    if (message.schemaB64 !== "") {
+      writer.uint32(26).string(message.schemaB64);
+    }
+    if (message.schemaShape !== undefined) {
+      SchemaShape.encode(message.schemaShape, writer.uint32(34).fork()).join();
+    }
+    if (message.definition !== undefined) {
+      StateMachineDefinition.encode(message.definition, writer.uint32(42).fork()).join();
+    }
+    if (message.strict !== false) {
+      writer.uint32(48).bool(message.strict);
+    }
+    globalThis.Object.entries(message.metadata).forEach(([key, value]: [string, string]) => {
+      PublishVersion_MetadataEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PublishVersion {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePublishVersion();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.schemaB64 = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.schemaShape = SchemaShape.decode(reader, reader.uint32());
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.definition = StateMachineDefinition.decode(reader, reader.uint32());
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.strict = reader.bool();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          const entry7 = PublishVersion_MetadataEntry.decode(reader, reader.uint32());
+          if (entry7.value !== undefined) {
+            message.metadata[entry7.key] = entry7.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PublishVersion {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      version: isSet(object.version) ? globalThis.String(object.version) : "",
+      schemaB64: isSet(object.schemaB64)
+        ? globalThis.String(object.schemaB64)
+        : isSet(object.schema_b64)
+        ? globalThis.String(object.schema_b64)
+        : "",
+      schemaShape: isSet(object.schemaShape)
+        ? SchemaShape.fromJSON(object.schemaShape)
+        : isSet(object.schema_shape)
+        ? SchemaShape.fromJSON(object.schema_shape)
+        : undefined,
+      definition: isSet(object.definition) ? StateMachineDefinition.fromJSON(object.definition) : undefined,
+      strict: isSet(object.strict) ? globalThis.Boolean(object.strict) : false,
+      metadata: isObject(object.metadata)
+        ? (globalThis.Object.entries(object.metadata) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+    };
+  },
+
+  toJSON(message: PublishVersion): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    if (message.schemaB64 !== "") {
+      obj.schemaB64 = message.schemaB64;
+    }
+    if (message.schemaShape !== undefined) {
+      obj.schemaShape = SchemaShape.toJSON(message.schemaShape);
+    }
+    if (message.definition !== undefined) {
+      obj.definition = StateMachineDefinition.toJSON(message.definition);
+    }
+    if (message.strict !== false) {
+      obj.strict = message.strict;
+    }
+    if (message.metadata) {
+      const entries = globalThis.Object.entries(message.metadata) as [string, string][];
+      if (entries.length > 0) {
+        obj.metadata = {};
+        entries.forEach(([k, v]) => {
+          obj.metadata[k] = v;
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PublishVersion>, I>>(base?: I): PublishVersion {
+    return PublishVersion.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<PublishVersion>, I>>(object: I): PublishVersion {
+    const message = createBasePublishVersion();
+    message.name = object.name ?? "";
+    message.version = object.version ?? "";
+    message.schemaB64 = object.schemaB64 ?? "";
+    message.schemaShape = (object.schemaShape !== undefined && object.schemaShape !== null)
+      ? SchemaShape.fromPartial(object.schemaShape)
+      : undefined;
+    message.definition = (object.definition !== undefined && object.definition !== null)
+      ? StateMachineDefinition.fromPartial(object.definition)
+      : undefined;
+    message.strict = object.strict ?? false;
+    message.metadata = (globalThis.Object.entries(object.metadata ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBasePublishVersion_MetadataEntry(): PublishVersion_MetadataEntry {
+  return { key: "", value: "" };
+}
+
+export const PublishVersion_MetadataEntry: MessageFns<PublishVersion_MetadataEntry> = {
+  encode(message: PublishVersion_MetadataEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PublishVersion_MetadataEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePublishVersion_MetadataEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PublishVersion_MetadataEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? globalThis.String(object.value) : "",
+    };
+  },
+
+  toJSON(message: PublishVersion_MetadataEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PublishVersion_MetadataEntry>, I>>(base?: I): PublishVersion_MetadataEntry {
+    return PublishVersion_MetadataEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<PublishVersion_MetadataEntry>, I>>(object: I): PublishVersion_MetadataEntry {
+    const message = createBasePublishVersion_MetadataEntry();
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
+    return message;
+  },
+};
+
+function createBaseSetVersionStatus(): SetVersionStatus {
+  return { name: "", version: "", status: RegistryStatus.REGISTRY_STATUS_UNSPECIFIED };
+}
+
+export const SetVersionStatus: MessageFns<SetVersionStatus> = {
+  encode(message: SetVersionStatus, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.version !== "") {
+      writer.uint32(18).string(message.version);
+    }
+    if (message.status !== RegistryStatus.REGISTRY_STATUS_UNSPECIFIED) {
+      writer.uint32(24).int32(registryStatusToNumber(message.status));
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SetVersionStatus {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSetVersionStatus();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.status = registryStatusFromJSON(reader.int32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SetVersionStatus {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      version: isSet(object.version) ? globalThis.String(object.version) : "",
+      status: isSet(object.status) ? registryStatusFromJSON(object.status) : RegistryStatus.REGISTRY_STATUS_UNSPECIFIED,
+    };
+  },
+
+  toJSON(message: SetVersionStatus): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    if (message.status !== RegistryStatus.REGISTRY_STATUS_UNSPECIFIED) {
+      obj.status = registryStatusToJSON(message.status);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SetVersionStatus>, I>>(base?: I): SetVersionStatus {
+    return SetVersionStatus.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SetVersionStatus>, I>>(object: I): SetVersionStatus {
+    const message = createBaseSetVersionStatus();
+    message.name = object.name ?? "";
+    message.version = object.version ?? "";
+    message.status = object.status ?? RegistryStatus.REGISTRY_STATUS_UNSPECIFIED;
+    return message;
+  },
+};
+
+function createBaseRegisterAlias(): RegisterAlias {
+  return { name: "", targetFiberId: "", metadata: {} };
+}
+
+export const RegisterAlias: MessageFns<RegisterAlias> = {
+  encode(message: RegisterAlias, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.targetFiberId !== "") {
+      writer.uint32(18).string(message.targetFiberId);
+    }
+    globalThis.Object.entries(message.metadata).forEach(([key, value]: [string, string]) => {
+      RegisterAlias_MetadataEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegisterAlias {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegisterAlias();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.targetFiberId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          const entry3 = RegisterAlias_MetadataEntry.decode(reader, reader.uint32());
+          if (entry3.value !== undefined) {
+            message.metadata[entry3.key] = entry3.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegisterAlias {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      targetFiberId: isSet(object.targetFiberId)
+        ? globalThis.String(object.targetFiberId)
+        : isSet(object.target_fiber_id)
+        ? globalThis.String(object.target_fiber_id)
+        : "",
+      metadata: isObject(object.metadata)
+        ? (globalThis.Object.entries(object.metadata) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+    };
+  },
+
+  toJSON(message: RegisterAlias): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.targetFiberId !== "") {
+      obj.targetFiberId = message.targetFiberId;
+    }
+    if (message.metadata) {
+      const entries = globalThis.Object.entries(message.metadata) as [string, string][];
+      if (entries.length > 0) {
+        obj.metadata = {};
+        entries.forEach(([k, v]) => {
+          obj.metadata[k] = v;
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegisterAlias>, I>>(base?: I): RegisterAlias {
+    return RegisterAlias.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegisterAlias>, I>>(object: I): RegisterAlias {
+    const message = createBaseRegisterAlias();
+    message.name = object.name ?? "";
+    message.targetFiberId = object.targetFiberId ?? "";
+    message.metadata = (globalThis.Object.entries(object.metadata ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBaseRegisterAlias_MetadataEntry(): RegisterAlias_MetadataEntry {
+  return { key: "", value: "" };
+}
+
+export const RegisterAlias_MetadataEntry: MessageFns<RegisterAlias_MetadataEntry> = {
+  encode(message: RegisterAlias_MetadataEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegisterAlias_MetadataEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegisterAlias_MetadataEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegisterAlias_MetadataEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? globalThis.String(object.value) : "",
+    };
+  },
+
+  toJSON(message: RegisterAlias_MetadataEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegisterAlias_MetadataEntry>, I>>(base?: I): RegisterAlias_MetadataEntry {
+    return RegisterAlias_MetadataEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegisterAlias_MetadataEntry>, I>>(object: I): RegisterAlias_MetadataEntry {
+    const message = createBaseRegisterAlias_MetadataEntry();
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
+    return message;
+  },
+};
+
 function createBaseOttochainMessage(): OttochainMessage {
   return { message: undefined };
 }
@@ -656,6 +1475,18 @@ export const OttochainMessage: MessageFns<OttochainMessage> = {
         break;
       case "invokeScript":
         InvokeScript.encode(message.message.invokeScript, writer.uint32(42).fork()).join();
+        break;
+      case "upgradeFiber":
+        UpgradeFiber.encode(message.message.upgradeFiber, writer.uint32(50).fork()).join();
+        break;
+      case "publishVersion":
+        PublishVersion.encode(message.message.publishVersion, writer.uint32(58).fork()).join();
+        break;
+      case "setVersionStatus":
+        SetVersionStatus.encode(message.message.setVersionStatus, writer.uint32(66).fork()).join();
+        break;
+      case "registerAlias":
+        RegisterAlias.encode(message.message.registerAlias, writer.uint32(74).fork()).join();
         break;
     }
     return writer;
@@ -717,6 +1548,41 @@ export const OttochainMessage: MessageFns<OttochainMessage> = {
           message.message = { $case: "invokeScript", invokeScript: InvokeScript.decode(reader, reader.uint32()) };
           continue;
         }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.message = { $case: "upgradeFiber", upgradeFiber: UpgradeFiber.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.message = { $case: "publishVersion", publishVersion: PublishVersion.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.message = {
+            $case: "setVersionStatus",
+            setVersionStatus: SetVersionStatus.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.message = { $case: "registerAlias", registerAlias: RegisterAlias.decode(reader, reader.uint32()) };
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -760,6 +1626,22 @@ export const OttochainMessage: MessageFns<OttochainMessage> = {
         ? { $case: "invokeScript", invokeScript: InvokeScript.fromJSON(object.invokeScript) }
         : isSet(object.invoke_script)
         ? { $case: "invokeScript", invokeScript: InvokeScript.fromJSON(object.invoke_script) }
+        : isSet(object.upgradeFiber)
+        ? { $case: "upgradeFiber", upgradeFiber: UpgradeFiber.fromJSON(object.upgradeFiber) }
+        : isSet(object.upgrade_fiber)
+        ? { $case: "upgradeFiber", upgradeFiber: UpgradeFiber.fromJSON(object.upgrade_fiber) }
+        : isSet(object.publishVersion)
+        ? { $case: "publishVersion", publishVersion: PublishVersion.fromJSON(object.publishVersion) }
+        : isSet(object.publish_version)
+        ? { $case: "publishVersion", publishVersion: PublishVersion.fromJSON(object.publish_version) }
+        : isSet(object.setVersionStatus)
+        ? { $case: "setVersionStatus", setVersionStatus: SetVersionStatus.fromJSON(object.setVersionStatus) }
+        : isSet(object.set_version_status)
+        ? { $case: "setVersionStatus", setVersionStatus: SetVersionStatus.fromJSON(object.set_version_status) }
+        : isSet(object.registerAlias)
+        ? { $case: "registerAlias", registerAlias: RegisterAlias.fromJSON(object.registerAlias) }
+        : isSet(object.register_alias)
+        ? { $case: "registerAlias", registerAlias: RegisterAlias.fromJSON(object.register_alias) }
         : undefined,
     };
   },
@@ -776,6 +1658,14 @@ export const OttochainMessage: MessageFns<OttochainMessage> = {
       obj.createScript = CreateScript.toJSON(message.message.createScript);
     } else if (message.message?.$case === "invokeScript") {
       obj.invokeScript = InvokeScript.toJSON(message.message.invokeScript);
+    } else if (message.message?.$case === "upgradeFiber") {
+      obj.upgradeFiber = UpgradeFiber.toJSON(message.message.upgradeFiber);
+    } else if (message.message?.$case === "publishVersion") {
+      obj.publishVersion = PublishVersion.toJSON(message.message.publishVersion);
+    } else if (message.message?.$case === "setVersionStatus") {
+      obj.setVersionStatus = SetVersionStatus.toJSON(message.message.setVersionStatus);
+    } else if (message.message?.$case === "registerAlias") {
+      obj.registerAlias = RegisterAlias.toJSON(message.message.registerAlias);
     }
     return obj;
   },
@@ -831,6 +1721,42 @@ export const OttochainMessage: MessageFns<OttochainMessage> = {
         }
         break;
       }
+      case "upgradeFiber": {
+        if (object.message?.upgradeFiber !== undefined && object.message?.upgradeFiber !== null) {
+          message.message = {
+            $case: "upgradeFiber",
+            upgradeFiber: UpgradeFiber.fromPartial(object.message.upgradeFiber),
+          };
+        }
+        break;
+      }
+      case "publishVersion": {
+        if (object.message?.publishVersion !== undefined && object.message?.publishVersion !== null) {
+          message.message = {
+            $case: "publishVersion",
+            publishVersion: PublishVersion.fromPartial(object.message.publishVersion),
+          };
+        }
+        break;
+      }
+      case "setVersionStatus": {
+        if (object.message?.setVersionStatus !== undefined && object.message?.setVersionStatus !== null) {
+          message.message = {
+            $case: "setVersionStatus",
+            setVersionStatus: SetVersionStatus.fromPartial(object.message.setVersionStatus),
+          };
+        }
+        break;
+      }
+      case "registerAlias": {
+        if (object.message?.registerAlias !== undefined && object.message?.registerAlias !== null) {
+          message.message = {
+            $case: "registerAlias",
+            registerAlias: RegisterAlias.fromPartial(object.message.registerAlias),
+          };
+        }
+        break;
+      }
     }
     return message;
   },
@@ -858,6 +1784,10 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+function isObject(value: any): boolean {
+  return typeof value === "object" && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/src/generated/ottochain/v1/records.ts
+++ b/src/generated/ottochain/v1/records.ts
@@ -7,6 +7,7 @@
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import { Value } from "../../google/protobuf/struct.js";
+import { RegistryEntry, SchemaBinding } from "./common.js";
 import {
   AccessControlPolicy,
   EventReceipt,
@@ -48,6 +49,8 @@ export interface StateMachineFiberRecord {
   lastReceipt?: EventReceipt | undefined;
   parentFiberId?: string | undefined;
   childFiberIds: string[];
+  /** The resolved, pinned registry binding (#26), present when created from a registered version. */
+  schemaBinding?: SchemaBinding | undefined;
 }
 
 /** Script fiber record - on-chain representation */
@@ -90,6 +93,8 @@ export interface FiberCommit {
 export interface OnChainState {
   fiberCommits: { [key: string]: FiberCommit };
   latestLogs: { [key: string]: FiberLogEntryList };
+  /** Per-registry-entry commitment hash, keyed by full registry name "labels.tld". */
+  registryCommits: { [key: string]: string };
 }
 
 export interface OnChainState_FiberCommitsEntry {
@@ -102,6 +107,11 @@ export interface OnChainState_LatestLogsEntry {
   value?: FiberLogEntryList | undefined;
 }
 
+export interface OnChainState_RegistryCommitsEntry {
+  key: string;
+  value: string;
+}
+
 /** Helper for map of log entries */
 export interface FiberLogEntryList {
   entries: FiberLogEntry[];
@@ -111,6 +121,14 @@ export interface FiberLogEntryList {
 export interface CalculatedState {
   stateMachines: { [key: string]: StateMachineFiberRecord };
   scripts: { [key: string]: ScriptFiberRecord };
+  /**
+   * Registry namespace, keyed by full registry name "labels.tld".
+   * Field is named `registry_entries` to avoid a synthetic map-entry name clash with the
+   * top-level RegistryEntry message; the JSON wire key stays `registry` via json_name.
+   */
+  registryEntries: { [key: string]: RegistryEntry };
+  /** Reverse records (#29): fiber UUID -> its canonical registered name. */
+  reverseNames: { [key: string]: string };
 }
 
 export interface CalculatedState_StateMachinesEntry {
@@ -121,6 +139,16 @@ export interface CalculatedState_StateMachinesEntry {
 export interface CalculatedState_ScriptsEntry {
   key: string;
   value?: ScriptFiberRecord | undefined;
+}
+
+export interface CalculatedState_RegistryEntriesEntry {
+  key: string;
+  value?: RegistryEntry | undefined;
+}
+
+export interface CalculatedState_ReverseNamesEntry {
+  key: string;
+  value: string;
 }
 
 function createBaseStateMachineFiberRecord(): StateMachineFiberRecord {
@@ -139,6 +167,7 @@ function createBaseStateMachineFiberRecord(): StateMachineFiberRecord {
     lastReceipt: undefined,
     parentFiberId: undefined,
     childFiberIds: [],
+    schemaBinding: undefined,
   };
 }
 
@@ -185,6 +214,9 @@ export const StateMachineFiberRecord: MessageFns<StateMachineFiberRecord> = {
     }
     for (const v of message.childFiberIds) {
       writer.uint32(114).string(v!);
+    }
+    if (message.schemaBinding !== undefined) {
+      SchemaBinding.encode(message.schemaBinding, writer.uint32(122).fork()).join();
     }
     return writer;
   },
@@ -308,6 +340,14 @@ export const StateMachineFiberRecord: MessageFns<StateMachineFiberRecord> = {
           message.childFiberIds.push(reader.string());
           continue;
         }
+        case 15: {
+          if (tag !== 122) {
+            break;
+          }
+
+          message.schemaBinding = SchemaBinding.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -377,6 +417,11 @@ export const StateMachineFiberRecord: MessageFns<StateMachineFiberRecord> = {
         : globalThis.Array.isArray(object?.child_fiber_ids)
         ? object.child_fiber_ids.map((e: any) => globalThis.String(e))
         : [],
+      schemaBinding: isSet(object.schemaBinding)
+        ? SchemaBinding.fromJSON(object.schemaBinding)
+        : isSet(object.schema_binding)
+        ? SchemaBinding.fromJSON(object.schema_binding)
+        : undefined,
     };
   },
 
@@ -424,6 +469,9 @@ export const StateMachineFiberRecord: MessageFns<StateMachineFiberRecord> = {
     if (message.childFiberIds?.length) {
       obj.childFiberIds = message.childFiberIds;
     }
+    if (message.schemaBinding !== undefined) {
+      obj.schemaBinding = SchemaBinding.toJSON(message.schemaBinding);
+    }
     return obj;
   },
 
@@ -450,6 +498,9 @@ export const StateMachineFiberRecord: MessageFns<StateMachineFiberRecord> = {
       : undefined;
     message.parentFiberId = object.parentFiberId ?? undefined;
     message.childFiberIds = object.childFiberIds?.map((e) => e) || [];
+    message.schemaBinding = (object.schemaBinding !== undefined && object.schemaBinding !== null)
+      ? SchemaBinding.fromPartial(object.schemaBinding)
+      : undefined;
     return message;
   },
 };
@@ -831,7 +882,7 @@ export const FiberCommit: MessageFns<FiberCommit> = {
 };
 
 function createBaseOnChainState(): OnChainState {
-  return { fiberCommits: {}, latestLogs: {} };
+  return { fiberCommits: {}, latestLogs: {}, registryCommits: {} };
 }
 
 export const OnChainState: MessageFns<OnChainState> = {
@@ -841,6 +892,9 @@ export const OnChainState: MessageFns<OnChainState> = {
     });
     globalThis.Object.entries(message.latestLogs).forEach(([key, value]: [string, FiberLogEntryList]) => {
       OnChainState_LatestLogsEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
+    });
+    globalThis.Object.entries(message.registryCommits).forEach(([key, value]: [string, string]) => {
+      OnChainState_RegistryCommitsEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
     return writer;
   },
@@ -871,6 +925,17 @@ export const OnChainState: MessageFns<OnChainState> = {
           const entry2 = OnChainState_LatestLogsEntry.decode(reader, reader.uint32());
           if (entry2.value !== undefined) {
             message.latestLogs[entry2.key] = entry2.value;
+          }
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          const entry3 = OnChainState_RegistryCommitsEntry.decode(reader, reader.uint32());
+          if (entry3.value !== undefined) {
+            message.registryCommits[entry3.key] = entry3.value;
           }
           continue;
         }
@@ -919,6 +984,23 @@ export const OnChainState: MessageFns<OnChainState> = {
           {},
         )
         : {},
+      registryCommits: isObject(object.registryCommits)
+        ? (globalThis.Object.entries(object.registryCommits) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : isObject(object.registry_commits)
+        ? (globalThis.Object.entries(object.registry_commits) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
     };
   },
 
@@ -939,6 +1021,15 @@ export const OnChainState: MessageFns<OnChainState> = {
         obj.latestLogs = {};
         entries.forEach(([k, v]) => {
           obj.latestLogs[k] = FiberLogEntryList.toJSON(v);
+        });
+      }
+    }
+    if (message.registryCommits) {
+      const entries = globalThis.Object.entries(message.registryCommits) as [string, string][];
+      if (entries.length > 0) {
+        obj.registryCommits = {};
+        entries.forEach(([k, v]) => {
+          obj.registryCommits[k] = v;
         });
       }
     }
@@ -963,6 +1054,15 @@ export const OnChainState: MessageFns<OnChainState> = {
       (acc: { [key: string]: FiberLogEntryList }, [key, value]: [string, FiberLogEntryList]) => {
         if (value !== undefined) {
           acc[key] = FiberLogEntryList.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    message.registryCommits = (globalThis.Object.entries(object.registryCommits ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
         }
         return acc;
       },
@@ -1130,6 +1230,86 @@ export const OnChainState_LatestLogsEntry: MessageFns<OnChainState_LatestLogsEnt
   },
 };
 
+function createBaseOnChainState_RegistryCommitsEntry(): OnChainState_RegistryCommitsEntry {
+  return { key: "", value: "" };
+}
+
+export const OnChainState_RegistryCommitsEntry: MessageFns<OnChainState_RegistryCommitsEntry> = {
+  encode(message: OnChainState_RegistryCommitsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): OnChainState_RegistryCommitsEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseOnChainState_RegistryCommitsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): OnChainState_RegistryCommitsEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? globalThis.String(object.value) : "",
+    };
+  },
+
+  toJSON(message: OnChainState_RegistryCommitsEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OnChainState_RegistryCommitsEntry>, I>>(
+    base?: I,
+  ): OnChainState_RegistryCommitsEntry {
+    return OnChainState_RegistryCommitsEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<OnChainState_RegistryCommitsEntry>, I>>(
+    object: I,
+  ): OnChainState_RegistryCommitsEntry {
+    const message = createBaseOnChainState_RegistryCommitsEntry();
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
+    return message;
+  },
+};
+
 function createBaseFiberLogEntryList(): FiberLogEntryList {
   return { entries: [] };
 }
@@ -1193,7 +1373,7 @@ export const FiberLogEntryList: MessageFns<FiberLogEntryList> = {
 };
 
 function createBaseCalculatedState(): CalculatedState {
-  return { stateMachines: {}, scripts: {} };
+  return { stateMachines: {}, scripts: {}, registryEntries: {}, reverseNames: {} };
 }
 
 export const CalculatedState: MessageFns<CalculatedState> = {
@@ -1203,6 +1383,12 @@ export const CalculatedState: MessageFns<CalculatedState> = {
     });
     globalThis.Object.entries(message.scripts).forEach(([key, value]: [string, ScriptFiberRecord]) => {
       CalculatedState_ScriptsEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
+    });
+    globalThis.Object.entries(message.registryEntries).forEach(([key, value]: [string, RegistryEntry]) => {
+      CalculatedState_RegistryEntriesEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
+    });
+    globalThis.Object.entries(message.reverseNames).forEach(([key, value]: [string, string]) => {
+      CalculatedState_ReverseNamesEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
     });
     return writer;
   },
@@ -1233,6 +1419,28 @@ export const CalculatedState: MessageFns<CalculatedState> = {
           const entry2 = CalculatedState_ScriptsEntry.decode(reader, reader.uint32());
           if (entry2.value !== undefined) {
             message.scripts[entry2.key] = entry2.value;
+          }
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          const entry3 = CalculatedState_RegistryEntriesEntry.decode(reader, reader.uint32());
+          if (entry3.value !== undefined) {
+            message.registryEntries[entry3.key] = entry3.value;
+          }
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          const entry4 = CalculatedState_ReverseNamesEntry.decode(reader, reader.uint32());
+          if (entry4.value !== undefined) {
+            message.reverseNames[entry4.key] = entry4.value;
           }
           continue;
         }
@@ -1273,6 +1481,40 @@ export const CalculatedState: MessageFns<CalculatedState> = {
           {},
         )
         : {},
+      registryEntries: isObject(object.registry)
+        ? (globalThis.Object.entries(object.registry) as [string, any][]).reduce(
+          (acc: { [key: string]: RegistryEntry }, [key, value]: [string, any]) => {
+            acc[key] = RegistryEntry.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
+        : isObject(object.registry_entries)
+        ? (globalThis.Object.entries(object.registry_entries) as [string, any][]).reduce(
+          (acc: { [key: string]: RegistryEntry }, [key, value]: [string, any]) => {
+            acc[key] = RegistryEntry.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+      reverseNames: isObject(object.reverseNames)
+        ? (globalThis.Object.entries(object.reverseNames) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : isObject(object.reverse_names)
+        ? (globalThis.Object.entries(object.reverse_names) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
     };
   },
 
@@ -1293,6 +1535,24 @@ export const CalculatedState: MessageFns<CalculatedState> = {
         obj.scripts = {};
         entries.forEach(([k, v]) => {
           obj.scripts[k] = ScriptFiberRecord.toJSON(v);
+        });
+      }
+    }
+    if (message.registryEntries) {
+      const entries = globalThis.Object.entries(message.registryEntries) as [string, RegistryEntry][];
+      if (entries.length > 0) {
+        obj.registry = {};
+        entries.forEach(([k, v]) => {
+          obj.registry[k] = RegistryEntry.toJSON(v);
+        });
+      }
+    }
+    if (message.reverseNames) {
+      const entries = globalThis.Object.entries(message.reverseNames) as [string, string][];
+      if (entries.length > 0) {
+        obj.reverseNames = {};
+        entries.forEach(([k, v]) => {
+          obj.reverseNames[k] = v;
         });
       }
     }
@@ -1318,6 +1578,22 @@ export const CalculatedState: MessageFns<CalculatedState> = {
       (acc: { [key: string]: ScriptFiberRecord }, [key, value]: [string, ScriptFiberRecord]) => {
         if (value !== undefined) {
           acc[key] = ScriptFiberRecord.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    message.registryEntries = (globalThis.Object.entries(object.registryEntries ?? {}) as [string, RegistryEntry][])
+      .reduce((acc: { [key: string]: RegistryEntry }, [key, value]: [string, RegistryEntry]) => {
+        if (value !== undefined) {
+          acc[key] = RegistryEntry.fromPartial(value);
+        }
+        return acc;
+      }, {});
+    message.reverseNames = (globalThis.Object.entries(object.reverseNames ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
         }
         return acc;
       },
@@ -1483,6 +1759,168 @@ export const CalculatedState_ScriptsEntry: MessageFns<CalculatedState_ScriptsEnt
     message.value = (object.value !== undefined && object.value !== null)
       ? ScriptFiberRecord.fromPartial(object.value)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseCalculatedState_RegistryEntriesEntry(): CalculatedState_RegistryEntriesEntry {
+  return { key: "", value: undefined };
+}
+
+export const CalculatedState_RegistryEntriesEntry: MessageFns<CalculatedState_RegistryEntriesEntry> = {
+  encode(message: CalculatedState_RegistryEntriesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      RegistryEntry.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CalculatedState_RegistryEntriesEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCalculatedState_RegistryEntriesEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = RegistryEntry.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CalculatedState_RegistryEntriesEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? RegistryEntry.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: CalculatedState_RegistryEntriesEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = RegistryEntry.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CalculatedState_RegistryEntriesEntry>, I>>(
+    base?: I,
+  ): CalculatedState_RegistryEntriesEntry {
+    return CalculatedState_RegistryEntriesEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CalculatedState_RegistryEntriesEntry>, I>>(
+    object: I,
+  ): CalculatedState_RegistryEntriesEntry {
+    const message = createBaseCalculatedState_RegistryEntriesEntry();
+    message.key = object.key ?? "";
+    message.value = (object.value !== undefined && object.value !== null)
+      ? RegistryEntry.fromPartial(object.value)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseCalculatedState_ReverseNamesEntry(): CalculatedState_ReverseNamesEntry {
+  return { key: "", value: "" };
+}
+
+export const CalculatedState_ReverseNamesEntry: MessageFns<CalculatedState_ReverseNamesEntry> = {
+  encode(message: CalculatedState_ReverseNamesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CalculatedState_ReverseNamesEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCalculatedState_ReverseNamesEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CalculatedState_ReverseNamesEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? globalThis.String(object.value) : "",
+    };
+  },
+
+  toJSON(message: CalculatedState_ReverseNamesEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CalculatedState_ReverseNamesEntry>, I>>(
+    base?: I,
+  ): CalculatedState_ReverseNamesEntry {
+    return CalculatedState_ReverseNamesEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CalculatedState_ReverseNamesEntry>, I>>(
+    object: I,
+  ): CalculatedState_ReverseNamesEntry {
+    const message = createBaseCalculatedState_ReverseNamesEntry();
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
     return message;
   },
 };

--- a/src/ottochain/index.ts
+++ b/src/ottochain/index.ts
@@ -32,10 +32,26 @@ export type {
   // State machine definition
   StateMachineDefinition,
 
+  // Registry: versioning, naming, schema shapes
+  SemVer,
+  RegistryStatus,
+  VersionReq,
+  SchemaRef,
+  FieldShape,
+  MessageShape,
+  SchemaShape,
+  SchemaBinding,
+  RegisteredVersion,
+  VersionLineage,
+  RegistryTarget,
+  RegistryEntry,
+
   // Log entries
   EmittedEvent,
   EventReceipt,
   OracleInvocation,
+  CreationReceipt,
+  UpgradeReceipt,
   FiberLogEntry,
 
   // Fiber records
@@ -54,8 +70,12 @@ export type {
   CreateStateMachine,
   TransitionStateMachine,
   ArchiveStateMachine,
+  UpgradeFiber,
   CreateScript,
   InvokeScript,
+  PublishVersion,
+  SetVersionStatus,
+  RegisterAlias,
   OttochainMessage,
   OttochainMessageType,
 } from './types.js';

--- a/src/ottochain/types.ts
+++ b/src/ottochain/types.ts
@@ -75,6 +75,180 @@ export interface StateMachineDefinition {
 }
 
 // ---------------------------------------------------------------------------
+// Registry: versioning, naming, and schema shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Semantic version `MAJOR.MINOR.PATCH`.
+ * Wire format: plain string (e.g. "1.0.0"). Also used as a JSON map key.
+ *
+ * @see modules/models/.../schema/registry/SemVer.scala
+ */
+export type SemVer = string;
+
+/**
+ * Lifecycle status of a registered version (npm/Cargo-style).
+ * Wire format: uppercase string (enumeratum `Uppercase`).
+ *
+ *  - `ACTIVE`     — selectable + recommended.
+ *  - `DEPRECATED` — still resolvable/runnable, flagged, discouraged for new instances.
+ *  - `YANKED`     — excluded from NEW resolutions; existing pinned fibers keep running.
+ *
+ * @see modules/models/.../schema/registry/RegistryStatus.scala
+ */
+export type RegistryStatus = 'ACTIVE' | 'DEPRECATED' | 'YANKED';
+
+/**
+ * A caller's version requirement, resolved against a {@link VersionLineage} (Cargo/npm-style).
+ * Wire format: single-key wrapper object (sealed-trait encoding).
+ *
+ *  - `Exact`      — exactly this version: `{"Exact":{"version":"1.0.0"}}`.
+ *  - `Caret`      — same MAJOR and `>= v` (`^1.2.0`).
+ *  - `Tilde`      — same MAJOR.MINOR and `>= v` (`~1.2.0`).
+ *  - `Latest`     — highest selectable version: `{"Latest":{}}`.
+ *  - `PinnedHash` — the exact artifact by schema hash, version-agnostic.
+ *
+ * @see modules/models/.../schema/registry/VersionReq.scala
+ */
+export type VersionReq =
+  | { Exact: { version: SemVer } }
+  | { Caret: { version: SemVer } }
+  | { Tilde: { version: SemVer } }
+  | { Latest: Record<string, never> }
+  | { PinnedHash: { schemaHash: string } };
+
+/**
+ * A caller's reference to a registered schema/program version, supplied at fiber creation
+ * (`CreateStateMachine.schemaRef`). The chain resolves `version` against the registry at create time.
+ * Wire format: `{"name":"counter.package","version":{"Exact":{"version":"1.0.0"}}}`.
+ *
+ * @see modules/models/.../schema/registry/SchemaRef.scala
+ */
+export interface SchemaRef {
+  /** Full registry name `labels.tld` (e.g. "counter.package"). */
+  name: string;
+  version: VersionReq;
+}
+
+/**
+ * One field of a {@link MessageShape} — mirrors a protobuf `FieldDescriptorProto`
+ * at the field level (name + field number + type).
+ * Wire format: `repeated`/`optional` default to `false` and are omittable.
+ *
+ * @see modules/models/.../schema/registry/SchemaShape.scala
+ */
+export interface FieldShape {
+  name: string;
+  number: number;
+  typeName: string;
+  repeated?: boolean;
+  optional?: boolean;
+}
+
+/**
+ * A single protobuf message shape: its type name plus its fields.
+ *
+ * @see modules/models/.../schema/registry/SchemaShape.scala
+ */
+export interface MessageShape {
+  typeName: string;
+  fields: FieldShape[];
+}
+
+/**
+ * The on-chain projection of a version's proto schema: the State message plus one
+ * message per command/event (keyed by event name). Publisher-claimed and advisory.
+ *
+ * @see modules/models/.../schema/registry/SchemaShape.scala
+ */
+export interface SchemaShape {
+  stateMessage: MessageShape;
+  /** One message per command/event, keyed by event name. */
+  commands: Record<string, MessageShape>;
+}
+
+/**
+ * The resolved, pinned binding recorded on a fiber: which registry (name, version) it
+ * instantiates, with the committed hashes. Resolved once at create, then immutable.
+ *
+ * @see modules/models/.../schema/registry/SchemaBinding.scala
+ */
+export interface SchemaBinding {
+  /** Full registry name `labels.tld`. */
+  name: string;
+  version: SemVer;
+  /** Commitment to the protobuf FileDescriptorSet (descriptor bytes; off-chain). */
+  schemaHash: string;
+  /** The verified-binding anchor: `StateMachineDefinition.computeDigest` of the logic. */
+  logicHash: string;
+}
+
+/**
+ * One immutable version of a registry entry. The chain commits only the hashes + the
+ * typed {@link SchemaShape} projection (never the descriptor or definition bytes).
+ * Wire format: `strict` defaults to `false` and is omittable.
+ *
+ * @see modules/models/.../schema/registry/RegisteredVersion.scala
+ */
+export interface RegisteredVersion {
+  version: SemVer;
+  /** Commitment to the protobuf FileDescriptorSet (descriptor bytes; off-chain). */
+  schemaHash: string;
+  /** The verified-binding anchor: `StateMachineDefinition.computeDigest` of the logic. */
+  logicHash: string;
+  schemaShape: SchemaShape;
+  status: RegistryStatus;
+  /** Snapshot ordinal at which this version was registered. */
+  registeredAt: number;
+  /** Opt-in runtime conformance gate (#33); defaults to `false`. */
+  strict?: boolean;
+}
+
+/**
+ * The append-only, monotonic version lineage of a single registry entry.
+ * Wire format: `versions` is a SemVer-string-keyed map of {@link RegisteredVersion}.
+ *
+ * @see modules/models/.../schema/registry/VersionLineage.scala
+ */
+export interface VersionLineage {
+  /** SemVer-string keyed map of registered versions. */
+  versions: Record<string, RegisteredVersion>;
+}
+
+/**
+ * What a registry entry resolves to, discriminated by the name's TLD.
+ * Wire format: single-key wrapper object (sealed-trait encoding).
+ *
+ *  - `SchemaPackage` (`.package`) — a versioned schema/program type (its {@link VersionLineage}).
+ *    Note the double-nesting: `SchemaPackage.versions` is a {@link VersionLineage} whose
+ *    own `.versions` is the SemVer-keyed map, e.g.
+ *    `{"SchemaPackage":{"versions":{"versions":{"1.0.0":{...}}}}}`.
+ *  - `InstanceAlias` (`.machine` / `.script`) — a nickname for an existing fiber (#29).
+ *
+ * @see modules/models/.../schema/registry/RegistryTarget.scala
+ */
+export type RegistryTarget =
+  | { SchemaPackage: { versions: VersionLineage } }
+  | { InstanceAlias: { fiberId: string } };
+
+/**
+ * A single owned entry in the registry namespace: a name -> a discriminated
+ * {@link RegistryTarget}, with the owning addresses and an optional off-chain metadata grab-bag.
+ * Wire format: `metadata` defaults to `{}` and is omittable.
+ *
+ * @see modules/models/.../schema/registry/RegistryEntry.scala
+ */
+export interface RegistryEntry {
+  /** Full registry name `labels.tld`. */
+  name: string;
+  /** Owning DAG addresses (who may publish versions / change status / transfer). */
+  owner: string[];
+  target: RegistryTarget;
+  /** Optional off-chain links grab-bag (e.g. "repo"/"homepage" -> URL). */
+  metadata?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
 // Log entries (FiberLogEntry)
 // ---------------------------------------------------------------------------
 
@@ -120,9 +294,41 @@ export interface OracleInvocation {
 }
 
 /**
+ * Birth record for a fiber, emitted once at creation. Records the resolved registry
+ * binding (name@version + committed hashes) when instantiated from a registered version
+ * (#26), or omits it for an ad-hoc fiber. Seeds the audit-trail rendering (#30).
+ *
+ * @see modules/models/.../schema/fiber/FiberLogEntry.scala
+ */
+export interface CreationReceipt {
+  fiberId: string;
+  ordinal: number; // Plain number (snapshot ordinal)
+  initialState: string; // Plain string (state id)
+  owners: string[]; // Plain string array (addresses)
+  schemaBinding?: SchemaBinding;
+  parentFiberId?: string;
+}
+
+/**
+ * Emitted when a fiber is upgraded to a different registered version (#27). Records the
+ * binding change (from -> to) and whether a state migration ran.
+ *
+ * @see modules/models/.../schema/fiber/FiberLogEntry.scala
+ */
+export interface UpgradeReceipt {
+  fiberId: string;
+  ordinal: number; // Plain number (snapshot ordinal)
+  /** Prior binding; absent for a fiber that had no registry binding before the upgrade. */
+  fromBinding?: SchemaBinding;
+  toBinding: SchemaBinding;
+  gasUsed: number;
+  migrated: boolean;
+}
+
+/**
  * Union type for all fiber log entries.
  */
-export type FiberLogEntry = EventReceipt | OracleInvocation;
+export type FiberLogEntry = EventReceipt | OracleInvocation | CreationReceipt | UpgradeReceipt;
 
 // ---------------------------------------------------------------------------
 // Fiber records
@@ -147,6 +353,8 @@ export interface StateMachineFiberRecord {
   lastReceipt?: EventReceipt;
   parentFiberId?: string;
   childFiberIds: string[];
+  /** The resolved, pinned registry binding (#26), present when created from a registered version. */
+  schemaBinding?: SchemaBinding;
 }
 
 /**
@@ -190,6 +398,8 @@ export interface FiberCommit {
 export interface OnChain {
   fiberCommits: Record<string, FiberCommit>;
   latestLogs: Record<string, FiberLogEntry[]>;
+  /** Per-registry-entry commitment hash, keyed by full registry name `labels.tld`. */
+  registryCommits: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +412,10 @@ export interface OnChain {
 export interface CalculatedState {
   stateMachines: Record<string, StateMachineFiberRecord>;
   scripts: Record<string, ScriptFiberRecord>;
+  /** Registry namespace, keyed by full registry name `labels.tld`. */
+  registry: Record<string, RegistryEntry>;
+  /** Reverse records (#29): fiber UUID -> its canonical registered name. */
+  reverseNames: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -218,6 +432,11 @@ export interface CreateStateMachine {
   parentFiberId?: string | null;
   /** Optional set of DAG addresses authorized to sign transitions (multi-party signing). */
   participants?: string[] | null;
+  /**
+   * Optional reference to a registered schema/program version (#26). When present, the chain
+   * resolves it against the registry at create time and records the verified {@link SchemaBinding}.
+   */
+  schemaRef?: SchemaRef | null;
 }
 
 /**
@@ -259,6 +478,68 @@ export interface InvokeScript {
 }
 
 /**
+ * Upgrade an existing fiber to a different registered version of the SAME package (#27).
+ * The chain verifies `newDefinition` hashes to the target version's `logicHash`, applies the
+ * optional `migration` (a JSON-Logic transform of the prior state data), preserves the current
+ * state id, and re-pins the binding.
+ */
+export interface UpgradeFiber {
+  fiberId: string;
+  targetRef: SchemaRef;
+  newDefinition: StateMachineDefinition;
+  /** Optional JSON-Logic transform applied to the prior state data during upgrade. */
+  migration?: JsonLogicExpression;
+  targetSequenceNumber: number;
+}
+
+/**
+ * Create-or-append a registry schema-package version (npm-publish semantics): the first publish
+ * for a name claims it and makes the signer the owner; later publishes require an existing owner.
+ *
+ * Note: `fiberId` is NOT on the wire — the chain derives the routing id from `name`.
+ */
+export interface PublishVersion {
+  /** Full registry name `labels.tld` (e.g. "order.package"). */
+  name: string;
+  version: SemVer;
+  /** Base64 of the proto FileDescriptorSet; the chain base64-validates + hashes it, then drops the bytes. */
+  schemaB64: string;
+  /** The typed proto projection the chain stores for discovery (advisory). */
+  schemaShape: SchemaShape;
+  /** The typed JSON-Logic state machine; hashed into `logicHash` for verified binding (#37). */
+  definition: StateMachineDefinition;
+  /** Opt-in runtime conformance gate (#33); defaults to `false`, omittable. */
+  strict?: boolean;
+  /** Optional off-chain links grab-bag set on the entry at first publish; defaults to `{}`, omittable. */
+  metadata?: Record<string, string>;
+}
+
+/**
+ * Change a registered version's lifecycle status (Active <-> Deprecated -> Yanked). Owner-gated.
+ */
+export interface SetVersionStatus {
+  /** Full registry name `labels.tld`. */
+  name: string;
+  version: SemVer;
+  status: RegistryStatus;
+}
+
+/**
+ * Register a human-readable nickname for an existing fiber (#29). The name's TLD must be
+ * `.machine` or `.script` and match the target fiber's kind; the signer must own the target.
+ *
+ * Note: `fiberId` is NOT on the wire — the chain derives the routing id from `name`.
+ */
+export interface RegisterAlias {
+  /** Full registry name `labels.tld` (e.g. "my-escrow.machine"). */
+  name: string;
+  /** The existing fiber UUID this alias points at. */
+  targetFiberId: string;
+  /** Optional off-chain links grab-bag; defaults to `{}`, omittable. */
+  metadata?: Record<string, string>;
+}
+
+/**
  * Union type for all ottochain messages.
  * JSON is wrapped as `{ MessageName: { ...fields } }`.
  */
@@ -266,8 +547,12 @@ export type OttochainMessage =
   | { CreateStateMachine: CreateStateMachine }
   | { TransitionStateMachine: TransitionStateMachine }
   | { ArchiveStateMachine: ArchiveStateMachine }
+  | { UpgradeFiber: UpgradeFiber }
   | { CreateScript: CreateScript }
-  | { InvokeScript: InvokeScript };
+  | { InvokeScript: InvokeScript }
+  | { PublishVersion: PublishVersion }
+  | { SetVersionStatus: SetVersionStatus }
+  | { RegisterAlias: RegisterAlias };
 
 /**
  * Names of all valid OttochainMessage types.
@@ -277,8 +562,12 @@ export const OTTOCHAIN_MESSAGE_TYPES = [
   'CreateStateMachine',
   'TransitionStateMachine',
   'ArchiveStateMachine',
+  'UpgradeFiber',
   'CreateScript',
   'InvokeScript',
+  'PublishVersion',
+  'SetVersionStatus',
+  'RegisterAlias',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Standardizes the `@ottochain/sdk` TypeScript types to fully mirror the ottochain chain's message + query surface. Every shape was verified against the chain (`xyz.kd5ujc.schema.*`) — the codec is camelCase fields, defaults-omittable, with sealed traits encoded as single-key wrapper objects.

The hand-written wire-format layer (`src/ottochain/types.ts`, surfaced via the `./core` subpath) was the critical target; the proto definitions and regenerated `src/generated/` were updated to match.

## What was added

### Messages (added to `OttochainMessage` union + `OTTOCHAIN_MESSAGE_TYPES`, in chain encoder order)
- **PublishVersion** — `{ name, version, schemaB64, schemaShape, definition, strict?, metadata? }` (no `fiberId` on the wire — the chain derives the routing id from `name`).
- **SetVersionStatus** — `{ name, version, status }`.
- **RegisterAlias** — `{ name, targetFiberId, metadata? }` (no `fiberId` on the wire).
- **UpgradeFiber** — `{ fiberId, targetRef, newDefinition, migration?, targetSequenceNumber }`.
- **CreateStateMachine** — gained `schemaRef?: SchemaRef | null` (existing `participants` field kept).

### Supporting types
- **SemVer** — string `"MAJOR.MINOR.PATCH"`.
- **RegistryStatus** — `'ACTIVE' | 'DEPRECATED' | 'YANKED'` (chain uses enumeratum `Uppercase`).
- **VersionReq** — single-key wrapper union: `Exact` / `Caret` / `Tilde` / `Latest` (`{"Latest":{}}`) / `PinnedHash`.
- **SchemaRef**, **FieldShape**, **MessageShape**, **SchemaShape**.

### Query/response types (so the SDK can read registry state)
- **CalculatedState** — gained `registry: Record<string, RegistryEntry>` and `reverseNames: Record<string, string>`.
- **OnChain** — gained `registryCommits: Record<string, string>`.
- **SchemaBinding**, **RegisteredVersion**, **VersionLineage** (SemVer-string keyed).
- **RegistryTarget** — single-key wrapper: `SchemaPackage` (double-nested: `SchemaPackage.versions` is a `VersionLineage` whose own `.versions` is the SemVer-keyed map) and `InstanceAlias` (`{ fiberId }`, read from `RegistryTarget.scala`).
- **RegistryEntry** — `{ name, owner: string[], target, metadata? }`.
- **FiberLogEntry** union — gained **CreationReceipt** and **UpgradeReceipt** (fields read from `FiberLogEntry.scala`).
- **StateMachineFiberRecord** — gained `schemaBinding?: SchemaBinding`.

### Proto + codegen
- Updated `proto/ottochain/v1/{messages,common,fiber,records}.proto` to mirror the new messages/types.
- **Regenerated `src/generated/` — regen is NOT required by a reviewer; it is already committed in this PR** (`buf generate` ran clean after the field-rename below; `protoc-gen-ts_proto` 1.66.0).
- The `CalculatedState` proto map field is named `registry_entries` with `json_name = "registry"` to avoid a synthetic map-entry name clash with the top-level `RegistryEntry` message — the JSON wire key stays `registry` (verified in the generated `toJSON`/`fromJSON`).

## Canonicalization

Verified that signing is **generic RFC-8785 over the object** (`signDataUpdate` → `toBytes(data, true)` → `canonicalize` → hash → sign), not per-type. The new optional fields are defaults-omittable (chain `useDefaults` + `dropNulls`), so **no `normalize.ts` / `transaction.ts` per-type changes are required** and none were made — the signed canonical stays byte-identical to what the chain re-derives.

## Verification
- `npm run generate` — clean (exit 0).
- `npm run build` (cjs + esm + types tsc passes) — clean.
- `npm test` — 48 suites passed, 1114 passed / 5 skipped.
- `eslint` on touched source — clean.

## Known follow-up (out of scope)
The pre-existing `FiberStatus` literal type is `'Active' | 'Archived' | 'Failed'`, but the chain emits **uppercase** (`FiberStatus extends Uppercase` → `'ACTIVE' | 'ARCHIVED' | 'FAILED'`; the chain e2e asserts `'ARCHIVED'`). Correcting this casing was left out of this PR because it is not part of the message/query surface in scope and would break existing SDK test fixtures (`tests/subscribe-fiber-state.test.ts` uses PascalCase). Flagging for a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)