### PR TITLE
feat: standard per-state metadata for std-app state machines

### DIFF
--- a/src/apps/contracts/state-machines/contract-agreement.ts
+++ b/src/apps/contracts/state-machines/contract-agreement.ts
@@ -90,12 +90,60 @@ export const contractAgreementDef = defineFiberApp({
   },
 
   states: {
-    PROPOSED: { id: "PROPOSED", isFinal: false, metadata: null },
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    COMPLETED: { id: "COMPLETED", isFinal: true, metadata: null },
-    DISPUTED: { id: "DISPUTED", isFinal: false, metadata: null },
-    REJECTED: { id: "REJECTED", isFinal: true, metadata: null },
-    CANCELLED: { id: "CANCELLED", isFinal: true, metadata: null },
+    PROPOSED: {
+      id: "PROPOSED",
+      isFinal: false,
+      metadata: {
+        label: "Proposed",
+        description: "Agreement proposed; awaiting the counterparty",
+        category: "initial",
+      },
+    },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Agreement accepted and in effect",
+        category: "active",
+      },
+    },
+    COMPLETED: {
+      id: "COMPLETED",
+      isFinal: true,
+      metadata: {
+        label: "Completed",
+        description: "Agreement completed and attested (terminal)",
+        category: "terminal",
+      },
+    },
+    DISPUTED: {
+      id: "DISPUTED",
+      isFinal: false,
+      metadata: {
+        label: "Disputed",
+        description: "A party has raised a dispute; awaiting resolution",
+        category: "pending",
+      },
+    },
+    REJECTED: {
+      id: "REJECTED",
+      isFinal: true,
+      metadata: {
+        label: "Rejected",
+        description: "Proposal rejected by the counterparty (terminal)",
+        category: "terminal",
+      },
+    },
+    CANCELLED: {
+      id: "CANCELLED",
+      isFinal: true,
+      metadata: {
+        label: "Cancelled",
+        description: "Agreement cancelled before completion (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "PROPOSED",

--- a/src/apps/contracts/state-machines/contract-escrow.ts
+++ b/src/apps/contracts/state-machines/contract-escrow.ts
@@ -127,14 +127,78 @@ export const contractEscrowDef = defineFiberApp({
   },
 
   states: {
-    CREATED: { id: "CREATED", isFinal: false, metadata: null },
-    FUNDED: { id: "FUNDED", isFinal: false, metadata: null },
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    RELEASING: { id: "RELEASING", isFinal: false, metadata: null },
-    DISPUTED: { id: "DISPUTED", isFinal: false, metadata: null },
-    RELEASED: { id: "RELEASED", isFinal: true, metadata: null },
-    REFUNDED: { id: "REFUNDED", isFinal: true, metadata: null },
-    SPLIT: { id: "SPLIT", isFinal: true, metadata: null },
+    CREATED: {
+      id: "CREATED",
+      isFinal: false,
+      metadata: {
+        label: "Created",
+        description: "Escrow created; awaiting funding",
+        category: "initial",
+      },
+    },
+    FUNDED: {
+      id: "FUNDED",
+      isFinal: false,
+      metadata: {
+        label: "Funded",
+        description: "Funds deposited into escrow",
+        category: "active",
+      },
+    },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Escrow in effect while work is performed",
+        category: "active",
+      },
+    },
+    RELEASING: {
+      id: "RELEASING",
+      isFinal: false,
+      metadata: {
+        label: "Releasing",
+        description: "Release approved; payout in progress",
+        category: "pending",
+      },
+    },
+    DISPUTED: {
+      id: "DISPUTED",
+      isFinal: false,
+      metadata: {
+        label: "Disputed",
+        description: "A party disputed the escrow; awaiting arbitration",
+        category: "pending",
+      },
+    },
+    RELEASED: {
+      id: "RELEASED",
+      isFinal: true,
+      metadata: {
+        label: "Released",
+        description: "Funds released to the beneficiary (terminal)",
+        category: "terminal",
+      },
+    },
+    REFUNDED: {
+      id: "REFUNDED",
+      isFinal: true,
+      metadata: {
+        label: "Refunded",
+        description: "Funds refunded to the depositor (terminal)",
+        category: "terminal",
+      },
+    },
+    SPLIT: {
+      id: "SPLIT",
+      isFinal: true,
+      metadata: {
+        label: "Split",
+        description: "Funds split between parties per arbitration (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "CREATED",

--- a/src/apps/contracts/state-machines/contract-universal.ts
+++ b/src/apps/contracts/state-machines/contract-universal.ts
@@ -32,10 +32,42 @@ export const contractUniversalDef = defineFiberApp({
   },
 
   states: {
-    PROPOSED: { id: "PROPOSED", isFinal: false, metadata: null },
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    COMPLETED: { id: "COMPLETED", isFinal: true, metadata: null },
-    CANCELLED: { id: "CANCELLED", isFinal: true, metadata: null },
+    PROPOSED: {
+      id: "PROPOSED",
+      isFinal: false,
+      metadata: {
+        label: "Proposed",
+        description: "Contract proposed; awaiting acceptance",
+        category: "initial",
+      },
+    },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Contract accepted and in effect",
+        category: "active",
+      },
+    },
+    COMPLETED: {
+      id: "COMPLETED",
+      isFinal: true,
+      metadata: {
+        label: "Completed",
+        description: "Contract obligations fulfilled (terminal)",
+        category: "terminal",
+      },
+    },
+    CANCELLED: {
+      id: "CANCELLED",
+      isFinal: true,
+      metadata: {
+        label: "Cancelled",
+        description: "Contract cancelled before completion (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "PROPOSED",

--- a/src/apps/governance/state-machines/dao-multisig.ts
+++ b/src/apps/governance/state-machines/dao-multisig.ts
@@ -124,9 +124,33 @@ export const daoMultisigDef = defineFiberApp({
   },
 
   states: {
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    PENDING: { id: "PENDING", isFinal: false, metadata: null },
-    DISSOLVED: { id: "DISSOLVED", isFinal: true, metadata: null },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Multisig is idle and ready to propose an action",
+        category: "initial",
+      },
+    },
+    PENDING: {
+      id: "PENDING",
+      isFinal: false,
+      metadata: {
+        label: "Pending",
+        description: "An action is awaiting the required signature threshold",
+        category: "pending",
+      },
+    },
+    DISSOLVED: {
+      id: "DISSOLVED",
+      isFinal: true,
+      metadata: {
+        label: "Dissolved",
+        description: "Multisig DAO dissolved (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "ACTIVE",

--- a/src/apps/governance/state-machines/dao-reputation.ts
+++ b/src/apps/governance/state-machines/dao-reputation.ts
@@ -132,9 +132,33 @@ export const daoReputationDef = defineFiberApp({
   },
 
   states: {
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    VOTING: { id: "VOTING", isFinal: false, metadata: null },
-    DISSOLVED: { id: "DISSOLVED", isFinal: true, metadata: null },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "DAO is idle and ready to accept a proposal",
+        category: "initial",
+      },
+    },
+    VOTING: {
+      id: "VOTING",
+      isFinal: false,
+      metadata: {
+        label: "Voting",
+        description: "Members vote with reputation-weighted power",
+        category: "pending",
+      },
+    },
+    DISSOLVED: {
+      id: "DISSOLVED",
+      isFinal: true,
+      metadata: {
+        label: "Dissolved",
+        description: "Reputation DAO dissolved (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "ACTIVE",

--- a/src/apps/governance/state-machines/dao-single.ts
+++ b/src/apps/governance/state-machines/dao-single.ts
@@ -81,9 +81,33 @@ export const daoSingleDef = defineFiberApp({
   },
 
   states: {
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    TRANSFERRING: { id: "TRANSFERRING", isFinal: false, metadata: null },
-    DISSOLVED: { id: "DISSOLVED", isFinal: true, metadata: null },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Single owner controls the DAO and may act or transfer ownership",
+        category: "initial",
+      },
+    },
+    TRANSFERRING: {
+      id: "TRANSFERRING",
+      isFinal: false,
+      metadata: {
+        label: "Transferring",
+        description: "Ownership transfer proposed; awaiting acceptance",
+        category: "pending",
+      },
+    },
+    DISSOLVED: {
+      id: "DISSOLVED",
+      isFinal: true,
+      metadata: {
+        label: "Dissolved",
+        description: "DAO dissolved by its owner (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "ACTIVE",

--- a/src/apps/governance/state-machines/dao-token.ts
+++ b/src/apps/governance/state-machines/dao-token.ts
@@ -134,10 +134,42 @@ export const daoTokenDef = defineFiberApp({
   },
 
   states: {
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    VOTING: { id: "VOTING", isFinal: false, metadata: null },
-    QUEUED: { id: "QUEUED", isFinal: false, metadata: null },
-    DISSOLVED: { id: "DISSOLVED", isFinal: true, metadata: null },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "DAO is idle and ready to accept a proposal",
+        category: "initial",
+      },
+    },
+    VOTING: {
+      id: "VOTING",
+      isFinal: false,
+      metadata: {
+        label: "Voting",
+        description: "Token holders are voting on the active proposal",
+        category: "pending",
+      },
+    },
+    QUEUED: {
+      id: "QUEUED",
+      isFinal: false,
+      metadata: {
+        label: "Queued",
+        description: "Passed proposal queued in timelock before execution",
+        category: "pending",
+      },
+    },
+    DISSOLVED: {
+      id: "DISSOLVED",
+      isFinal: true,
+      metadata: {
+        label: "Dissolved",
+        description: "Token DAO dissolved (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "ACTIVE",

--- a/src/apps/governance/state-machines/governance-simple.ts
+++ b/src/apps/governance/state-machines/governance-simple.ts
@@ -136,10 +136,42 @@ export const govSimpleDef = defineFiberApp({
   },
 
   states: {
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    VOTING: { id: "VOTING", isFinal: false, metadata: null },
-    DISPUTE: { id: "DISPUTE", isFinal: false, metadata: null },
-    DISSOLVED: { id: "DISSOLVED", isFinal: true, metadata: null },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Governance is idle and ready to accept a proposal",
+        category: "initial",
+      },
+    },
+    VOTING: {
+      id: "VOTING",
+      isFinal: false,
+      metadata: {
+        label: "Voting",
+        description: "A proposal is open for voting",
+        category: "pending",
+      },
+    },
+    DISPUTE: {
+      id: "DISPUTE",
+      isFinal: false,
+      metadata: {
+        label: "Dispute",
+        description: "A proposal outcome is being disputed",
+        category: "pending",
+      },
+    },
+    DISSOLVED: {
+      id: "DISSOLVED",
+      isFinal: true,
+      metadata: {
+        label: "Dissolved",
+        description: "Governance entity dissolved (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "ACTIVE",

--- a/src/apps/governance/state-machines/governance-universal.ts
+++ b/src/apps/governance/state-machines/governance-universal.ts
@@ -55,9 +55,33 @@ export const govUniversalDef = defineFiberApp({
   },
 
   states: {
-    ACTIVE: { id: "ACTIVE", isFinal: false, metadata: null },
-    VOTING: { id: "VOTING", isFinal: false, metadata: null },
-    DISSOLVED: { id: "DISSOLVED", isFinal: true, metadata: null },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Governance is idle and ready to accept a proposal",
+        category: "initial",
+      },
+    },
+    VOTING: {
+      id: "VOTING",
+      isFinal: false,
+      metadata: {
+        label: "Voting",
+        description: "A proposal is open for voting",
+        category: "pending",
+      },
+    },
+    DISSOLVED: {
+      id: "DISSOLVED",
+      isFinal: true,
+      metadata: {
+        label: "Dissolved",
+        description: "Governance entity dissolved (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "ACTIVE",

--- a/src/apps/identity/state-machines/identity-agent.ts
+++ b/src/apps/identity/state-machines/identity-agent.ts
@@ -136,12 +136,60 @@ export const identityAgentDef = defineFiberApp({
   },
 
   states: {
-    REGISTERED: { id: "REGISTERED", isFinal: false },
-    ACTIVE: { id: "ACTIVE", isFinal: false },
-    CHALLENGED: { id: "CHALLENGED", isFinal: false },
-    SUSPENDED: { id: "SUSPENDED", isFinal: false },
-    PROBATION: { id: "PROBATION", isFinal: false },
-    WITHDRAWN: { id: "WITHDRAWN", isFinal: true },
+    REGISTERED: {
+      id: "REGISTERED",
+      isFinal: false,
+      metadata: {
+        label: "Registered",
+        description: "Agent registered but not yet activated",
+        category: "initial",
+      },
+    },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Agent is active and accruing reputation",
+        category: "active",
+      },
+    },
+    CHALLENGED: {
+      id: "CHALLENGED",
+      isFinal: false,
+      metadata: {
+        label: "Challenged",
+        description: "A challenge has been raised; awaiting resolution",
+        category: "pending",
+      },
+    },
+    SUSPENDED: {
+      id: "SUSPENDED",
+      isFinal: false,
+      metadata: {
+        label: "Suspended",
+        description: "Agent suspended after an upheld challenge",
+        category: "pending",
+      },
+    },
+    PROBATION: {
+      id: "PROBATION",
+      isFinal: false,
+      metadata: {
+        label: "Probation",
+        description: "Conditional reinstatement under monitoring",
+        category: "active",
+      },
+    },
+    WITHDRAWN: {
+      id: "WITHDRAWN",
+      isFinal: true,
+      metadata: {
+        label: "Withdrawn",
+        description: "Agent withdrawn from the registry (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "REGISTERED",

--- a/src/apps/identity/state-machines/identity-oracle.ts
+++ b/src/apps/identity/state-machines/identity-oracle.ts
@@ -135,11 +135,51 @@ export const identityOracleDef = defineFiberApp({
   },
 
   states: {
-    UNREGISTERED: { id: "UNREGISTERED", isFinal: false },
-    REGISTERED: { id: "REGISTERED", isFinal: false },
-    ACTIVE: { id: "ACTIVE", isFinal: false },
-    SLASHED: { id: "SLASHED", isFinal: false },
-    WITHDRAWN: { id: "WITHDRAWN", isFinal: true },
+    UNREGISTERED: {
+      id: "UNREGISTERED",
+      isFinal: false,
+      metadata: {
+        label: "Unregistered",
+        description: "Oracle not yet registered; awaiting stake",
+        category: "initial",
+      },
+    },
+    REGISTERED: {
+      id: "REGISTERED",
+      isFinal: false,
+      metadata: {
+        label: "Registered",
+        description: "Oracle staked and registered but not yet active",
+        category: "pending",
+      },
+    },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Oracle is active and may submit resolutions",
+        category: "active",
+      },
+    },
+    SLASHED: {
+      id: "SLASHED",
+      isFinal: false,
+      metadata: {
+        label: "Slashed",
+        description: "Oracle penalized for a lost dispute; stake reduced",
+        category: "pending",
+      },
+    },
+    WITHDRAWN: {
+      id: "WITHDRAWN",
+      isFinal: true,
+      metadata: {
+        label: "Withdrawn",
+        description: "Oracle withdrawn and stake reclaimed (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "UNREGISTERED",

--- a/src/apps/identity/state-machines/identity-universal.ts
+++ b/src/apps/identity/state-machines/identity-universal.ts
@@ -59,9 +59,33 @@ export const identityUniversalDef = defineFiberApp({
   },
 
   states: {
-    CREATED: { id: "CREATED", isFinal: false },
-    ACTIVE: { id: "ACTIVE", isFinal: false },
-    INACTIVE: { id: "INACTIVE", isFinal: true },
+    CREATED: {
+      id: "CREATED",
+      isFinal: false,
+      metadata: {
+        label: "Created",
+        description: "Identity registered but not yet activated",
+        category: "initial",
+      },
+    },
+    ACTIVE: {
+      id: "ACTIVE",
+      isFinal: false,
+      metadata: {
+        label: "Active",
+        description: "Identity is active and can be updated",
+        category: "active",
+      },
+    },
+    INACTIVE: {
+      id: "INACTIVE",
+      isFinal: true,
+      metadata: {
+        label: "Inactive",
+        description: "Identity deactivated by its owner (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "CREATED",

--- a/src/apps/markets/state-machines/market-auction.ts
+++ b/src/apps/markets/state-machines/market-auction.ts
@@ -76,32 +76,56 @@ export const marketAuctionDef = defineFiberApp({
     PROPOSED: {
       id: "PROPOSED",
       isFinal: false,
-      metadata: { description: "Auction created but not yet open" },
+      metadata: {
+        label: "Proposed",
+        description: "Auction created but not yet open",
+        category: "initial",
+      },
     },
     OPEN: {
       id: "OPEN",
       isFinal: false,
-      metadata: { description: "Accepting bids" },
+      metadata: {
+        label: "Open",
+        description: "Accepting bids",
+        category: "active",
+      },
     },
     CLOSING: {
       id: "CLOSING",
       isFinal: false,
-      metadata: { description: "Bid period ended, determining winner" },
+      metadata: {
+        label: "Closing",
+        description: "Bid period ended, determining winner",
+        category: "pending",
+      },
     },
     SETTLED: {
       id: "SETTLED",
       isFinal: true,
-      metadata: { description: "Winner determined, transfer complete" },
+      metadata: {
+        label: "Settled",
+        description: "Winner determined, transfer complete",
+        category: "terminal",
+      },
     },
     NO_SALE: {
       id: "NO_SALE",
       isFinal: true,
-      metadata: { description: "Reserve not met or no valid bids" },
+      metadata: {
+        label: "No sale",
+        description: "Reserve not met or no valid bids",
+        category: "terminal",
+      },
     },
     CANCELLED: {
       id: "CANCELLED",
       isFinal: true,
-      metadata: { description: "Auction cancelled by seller" },
+      metadata: {
+        label: "Cancelled",
+        description: "Auction cancelled by seller",
+        category: "terminal",
+      },
     },
   },
 

--- a/src/apps/markets/state-machines/market-crowdfund.ts
+++ b/src/apps/markets/state-machines/market-crowdfund.ts
@@ -84,27 +84,47 @@ export const marketCrowdfundDef = defineFiberApp({
     PROPOSED: {
       id: "PROPOSED",
       isFinal: false,
-      metadata: { description: "Campaign created but not yet open" },
+      metadata: {
+        label: "Proposed",
+        description: "Campaign created but not yet open",
+        category: "initial",
+      },
     },
     OPEN: {
       id: "OPEN",
       isFinal: false,
-      metadata: { description: "Accepting pledges" },
+      metadata: {
+        label: "Open",
+        description: "Accepting pledges",
+        category: "active",
+      },
     },
     FUNDED: {
       id: "FUNDED",
       isFinal: true,
-      metadata: { description: "Threshold met, funds released to creator" },
+      metadata: {
+        label: "Funded",
+        description: "Threshold met, funds released to creator",
+        category: "terminal",
+      },
     },
     REFUNDED: {
       id: "REFUNDED",
       isFinal: true,
-      metadata: { description: "Threshold not met, all pledges refunded" },
+      metadata: {
+        label: "Refunded",
+        description: "Threshold not met, all pledges refunded",
+        category: "terminal",
+      },
     },
     CANCELLED: {
       id: "CANCELLED",
       isFinal: true,
-      metadata: { description: "Campaign cancelled by creator" },
+      metadata: {
+        label: "Cancelled",
+        description: "Campaign cancelled by creator",
+        category: "terminal",
+      },
     },
   },
 

--- a/src/apps/markets/state-machines/market-group-buy.ts
+++ b/src/apps/markets/state-machines/market-group-buy.ts
@@ -86,41 +86,65 @@ export const marketGroupBuyDef = defineFiberApp({
     PROPOSED: {
       id: "PROPOSED",
       isFinal: false,
-      metadata: { description: "Group buy created but not yet open" },
+      metadata: {
+        label: "Proposed",
+        description: "Group buy created but not yet open",
+        category: "initial",
+      },
     },
     OPEN: {
       id: "OPEN",
       isFinal: false,
-      metadata: { description: "Accepting orders" },
+      metadata: {
+        label: "Open",
+        description: "Accepting orders",
+        category: "active",
+      },
     },
     THRESHOLD_MET: {
       id: "THRESHOLD_MET",
       isFinal: false,
       metadata: {
+        label: "Threshold met",
         description: "Minimum quantity reached, continuing for better tier",
+        category: "active",
       },
     },
     PROCESSING: {
       id: "PROCESSING",
       isFinal: false,
       metadata: {
+        label: "Processing",
         description: "Order placed with vendor, awaiting fulfillment",
+        category: "pending",
       },
     },
     FULFILLED: {
       id: "FULFILLED",
       isFinal: true,
-      metadata: { description: "All items delivered to buyers" },
+      metadata: {
+        label: "Fulfilled",
+        description: "All items delivered to buyers",
+        category: "terminal",
+      },
     },
     REFUNDED: {
       id: "REFUNDED",
       isFinal: true,
-      metadata: { description: "Threshold not met, all orders refunded" },
+      metadata: {
+        label: "Refunded",
+        description: "Threshold not met, all orders refunded",
+        category: "terminal",
+      },
     },
     CANCELLED: {
       id: "CANCELLED",
       isFinal: true,
-      metadata: { description: "Group buy cancelled" },
+      metadata: {
+        label: "Cancelled",
+        description: "Group buy cancelled",
+        category: "terminal",
+      },
     },
   },
 

--- a/src/apps/markets/state-machines/market-prediction.ts
+++ b/src/apps/markets/state-machines/market-prediction.ts
@@ -114,42 +114,74 @@ export const marketPredictionDef = defineFiberApp({
     PROPOSED: {
       id: "PROPOSED",
       isFinal: false,
-      metadata: { description: "Market created but not yet open for trading" },
+      metadata: {
+        label: "Proposed",
+        description: "Market created but not yet open for trading",
+        category: "initial",
+      },
     },
     OPEN: {
       id: "OPEN",
       isFinal: false,
-      metadata: { description: "Accepting positions on outcomes" },
+      metadata: {
+        label: "Open",
+        description: "Accepting positions on outcomes",
+        category: "active",
+      },
     },
     CLOSED: {
       id: "CLOSED",
       isFinal: false,
-      metadata: { description: "No more positions, awaiting resolution" },
+      metadata: {
+        label: "Closed",
+        description: "No more positions, awaiting resolution",
+        category: "pending",
+      },
     },
     RESOLVING: {
       id: "RESOLVING",
       isFinal: false,
-      metadata: { description: "Oracle(s) submitting resolution" },
+      metadata: {
+        label: "Resolving",
+        description: "Oracle(s) submitting resolution",
+        category: "pending",
+      },
     },
     DISPUTED: {
       id: "DISPUTED",
       isFinal: false,
-      metadata: { description: "Resolution challenged, awaiting arbitration" },
+      metadata: {
+        label: "Disputed",
+        description: "Resolution challenged, awaiting arbitration",
+        category: "pending",
+      },
     },
     SETTLED: {
       id: "SETTLED",
       isFinal: true,
-      metadata: { description: "Outcome finalized, payouts available" },
+      metadata: {
+        label: "Settled",
+        description: "Outcome finalized, payouts available",
+        category: "terminal",
+      },
     },
     REFUNDED: {
       id: "REFUNDED",
       isFinal: true,
-      metadata: { description: "Market invalidated, all positions refunded" },
+      metadata: {
+        label: "Refunded",
+        description: "Market invalidated, all positions refunded",
+        category: "terminal",
+      },
     },
     CANCELLED: {
       id: "CANCELLED",
       isFinal: true,
-      metadata: { description: "Market cancelled before opening" },
+      metadata: {
+        label: "Cancelled",
+        description: "Market cancelled before opening",
+        category: "terminal",
+      },
     },
   },
 

--- a/src/apps/markets/state-machines/market-universal.ts
+++ b/src/apps/markets/state-machines/market-universal.ts
@@ -37,11 +37,51 @@ export const marketUniversalDef = defineFiberApp({
   },
 
   states: {
-    PROPOSED: { id: "PROPOSED", isFinal: false, metadata: null },
-    OPEN: { id: "OPEN", isFinal: false, metadata: null },
-    CLOSED: { id: "CLOSED", isFinal: false, metadata: null },
-    SETTLED: { id: "SETTLED", isFinal: true, metadata: null },
-    CANCELLED: { id: "CANCELLED", isFinal: true, metadata: null },
+    PROPOSED: {
+      id: "PROPOSED",
+      isFinal: false,
+      metadata: {
+        label: "Proposed",
+        description: "Market created but not yet open",
+        category: "initial",
+      },
+    },
+    OPEN: {
+      id: "OPEN",
+      isFinal: false,
+      metadata: {
+        label: "Open",
+        description: "Market is open for participation",
+        category: "active",
+      },
+    },
+    CLOSED: {
+      id: "CLOSED",
+      isFinal: false,
+      metadata: {
+        label: "Closed",
+        description: "Participation closed; awaiting settlement",
+        category: "pending",
+      },
+    },
+    SETTLED: {
+      id: "SETTLED",
+      isFinal: true,
+      metadata: {
+        label: "Settled",
+        description: "Market settled and payouts available (terminal)",
+        category: "terminal",
+      },
+    },
+    CANCELLED: {
+      id: "CANCELLED",
+      isFinal: true,
+      metadata: {
+        label: "Cancelled",
+        description: "Market cancelled before settlement (terminal)",
+        category: "terminal",
+      },
+    },
   },
 
   initialState: "PROPOSED",

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,5 +141,7 @@ export {
   type FiberAppDefinition,
   type FiberAppMetadata,
   type StateDefinition,
+  type StdStateMetadata,
+  type StateCategory,
   type Transition,
 } from './schema/fiber-app.js';

--- a/src/schema/fiber-app.ts
+++ b/src/schema/fiber-app.ts
@@ -74,11 +74,52 @@ export interface EventSchema {
 // State Machine Core (matches metagraph)
 // =============================================================================
 
+/**
+ * Lifecycle category for a state — a small fixed vocabulary that lets UIs group
+ * and color states and lets analytics bucket fibers without app-specific logic.
+ *
+ * - `initial`  — the machine's `initialState` (entry point)
+ * - `active`   — a normal, operational, non-terminal state
+ * - `pending`  — a transient state awaiting an action/condition/timeout
+ * - `terminal` — a final state (`isFinal: true`); the machine ends here
+ */
+export type StateCategory = 'initial' | 'active' | 'pending' | 'terminal';
+
+/**
+ * Standard per-state metadata convention for OttoChain std apps.
+ *
+ * This is the minimal, high-value block we attach to every standard state
+ * definition (instead of `metadata: null`). It is plain JSON, so it survives
+ * the client/server null-dropping canonicalization (only NULL fields are
+ * dropped; a populated object is kept and signed/verified identically on both
+ * sides). Custom apps may extend `StateDefinition.metadata` with extra keys.
+ *
+ * Fields:
+ * - `label`       — short human-readable title for the state (e.g. "Active")
+ * - `description` — one-line explanation of what the state means
+ * - `category`    — optional lifecycle hint (see {@link StateCategory})
+ */
+export interface StdStateMetadata {
+  /** Short human-readable title, e.g. "Voting". */
+  label: string;
+  /** One-line description of what this state represents. */
+  description: string;
+  /** Optional lifecycle category hint for UIs / analytics. */
+  category?: StateCategory;
+}
+
 export interface StateDefinition {
   id: string;
   isFinal: boolean;
   description?: string;
-  metadata?: Record<string, unknown> | null;
+  /**
+   * Optional per-state metadata. Std apps populate the {@link StdStateMetadata}
+   * convention (`label` / `description` / `category`); custom apps may use any
+   * JSON object or `null`. NOTE: a `null` here is stripped from the signed wire
+   * form (the chain drops null object-fields), so prefer populated metadata or
+   * omit the field entirely.
+   */
+  metadata?: StdStateMetadata | Record<string, unknown> | null;
 }
 
 export type JsonLogicRule = Record<string, unknown>;

--- a/tests/apps-std-metadata.test.ts
+++ b/tests/apps-std-metadata.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Standard per-state metadata convention for std apps.
+ *
+ * Every standard state-machine state must carry the { label, description,
+ * category } block instead of `metadata: null`. A populated (non-null) metadata
+ * object survives the client/server null-dropping canonicalization, so these
+ * definitions sign/verify identically on both sides (unlike `metadata: null`,
+ * which the chain drops and which previously broke signature verification).
+ */
+
+import { identity, governance, markets, contracts } from '../src/apps/index.js';
+import type { FiberAppDefinition, StateCategory } from '../src/schema/fiber-app.js';
+
+const VALID_CATEGORIES: StateCategory[] = ['initial', 'active', 'pending', 'terminal'];
+
+// Collect every std-app definition we populated with standard state metadata.
+const ALL_DEFS: Record<string, FiberAppDefinition> = {
+  // identity
+  identityUniversal: identity.identityUniversalDef,
+  identityAgent: identity.identityAgentDef,
+  identityOracle: identity.identityOracleDef,
+  // governance
+  govUniversal: governance.govUniversalDef,
+  govSimple: governance.govSimpleDef,
+  daoSingle: governance.daoSingleDef,
+  daoMultisig: governance.daoMultisigDef,
+  daoToken: governance.daoTokenDef,
+  daoReputation: governance.daoReputationDef,
+  // markets
+  marketUniversal: markets.marketUniversalDef,
+  marketPrediction: markets.marketPredictionDef,
+  marketAuction: markets.marketAuctionDef,
+  marketCrowdfund: markets.marketCrowdfundDef,
+  marketGroupBuy: markets.marketGroupBuyDef,
+  // contracts
+  contractUniversal: contracts.contractUniversalDef,
+  contractAgreement: contracts.contractAgreementDef,
+  contractEscrow: contracts.contractEscrowDef,
+};
+
+describe('std-app standard state metadata', () => {
+  for (const [name, def] of Object.entries(ALL_DEFS)) {
+    describe(name, () => {
+      it('has a non-null { label, description } block on every state', () => {
+        const states = Object.entries(def.states);
+        expect(states.length).toBeGreaterThan(0);
+        for (const [stateId, state] of states) {
+          // No state may be null (the chain drops null object-fields).
+          expect(state.metadata).not.toBeNull();
+          expect(state.metadata).toBeDefined();
+          const meta = state.metadata as Record<string, unknown>;
+          expect(typeof meta.label).toBe('string');
+          expect((meta.label as string).length).toBeGreaterThan(0);
+          expect(typeof meta.description).toBe('string');
+          expect((meta.description as string).length).toBeGreaterThan(0);
+          // category, when present, is from the fixed vocabulary.
+          if (meta.category !== undefined) {
+            expect(VALID_CATEGORIES).toContain(meta.category as StateCategory);
+          }
+          // Sanity: stateId matches the embedded id.
+          expect(state.id).toBe(stateId);
+        }
+      });
+
+      it('marks the initialState as category "initial" and final states as "terminal"', () => {
+        const initial = def.states[def.initialState];
+        expect((initial.metadata as Record<string, unknown>).category).toBe('initial');
+        for (const state of Object.values(def.states)) {
+          const category = (state.metadata as Record<string, unknown>).category;
+          if (state.isFinal) {
+            expect(category).toBe('terminal');
+          } else {
+            // non-final states are never 'terminal'
+            expect(category).not.toBe('terminal');
+          }
+        }
+      });
+    });
+  }
+});

--- a/tests/contracts-state-machine-conversion.test.ts
+++ b/tests/contracts-state-machine-conversion.test.ts
@@ -51,38 +51,31 @@ describe('Contracts State Machine Conversion', () => {
       });
     });
 
-    it('should have proper state definitions', () => {
+    it('should have proper state definitions with standard metadata', () => {
       expect(contractAgreementDef.states).toBeDefined();
-      expect(contractAgreementDef.states.PROPOSED).toEqual({
-        id: 'PROPOSED',
-        isFinal: false,
-        metadata: null,
-      });
-      expect(contractAgreementDef.states.ACTIVE).toEqual({
-        id: 'ACTIVE', 
-        isFinal: false,
-        metadata: null,
-      });
-      expect(contractAgreementDef.states.COMPLETED).toEqual({
-        id: 'COMPLETED',
-        isFinal: true,
-        metadata: null,
-      });
-      expect(contractAgreementDef.states.DISPUTED).toEqual({
-        id: 'DISPUTED',
-        isFinal: false,
-        metadata: null,
-      });
-      expect(contractAgreementDef.states.REJECTED).toEqual({
-        id: 'REJECTED',
-        isFinal: true,
-        metadata: null,
-      });
-      expect(contractAgreementDef.states.CANCELLED).toEqual({
-        id: 'CANCELLED',
-        isFinal: true,
-        metadata: null,
-      });
+
+      // id / isFinal are unchanged; metadata is now the standard
+      // { label, description, category } block (no longer null) so the
+      // definition survives the client/server null-dropping canonicalization.
+      const expected: Record<string, { isFinal: boolean; category: string }> = {
+        PROPOSED: { isFinal: false, category: 'initial' },
+        ACTIVE: { isFinal: false, category: 'active' },
+        COMPLETED: { isFinal: true, category: 'terminal' },
+        DISPUTED: { isFinal: false, category: 'pending' },
+        REJECTED: { isFinal: true, category: 'terminal' },
+        CANCELLED: { isFinal: true, category: 'terminal' },
+      };
+
+      for (const [id, exp] of Object.entries(expected)) {
+        const state = contractAgreementDef.states[id];
+        expect(state.id).toBe(id);
+        expect(state.isFinal).toBe(exp.isFinal);
+        expect(state.metadata).not.toBeNull();
+        const meta = state.metadata as Record<string, unknown>;
+        expect(typeof meta.label).toBe('string');
+        expect(typeof meta.description).toBe('string');
+        expect(meta.category).toBe(exp.category);
+      }
     });
 
     it('should define proper transitions with events', () => {

--- a/tests/markets/market-universal.test.ts
+++ b/tests/markets/market-universal.test.ts
@@ -14,12 +14,24 @@ describe('MarketUniversal State Machine', () => {
     expect(marketUniversalDef.metadata.version).toBe('1.0.0');
   });
 
-  it('should have minimal states', () => {
-    expect(marketUniversalDef.states.PROPOSED).toEqual({ id: 'PROPOSED', isFinal: false, metadata: null });
-    expect(marketUniversalDef.states.OPEN).toEqual({ id: 'OPEN', isFinal: false, metadata: null });
-    expect(marketUniversalDef.states.CLOSED).toEqual({ id: 'CLOSED', isFinal: false, metadata: null });
-    expect(marketUniversalDef.states.SETTLED).toEqual({ id: 'SETTLED', isFinal: true, metadata: null });
-    expect(marketUniversalDef.states.CANCELLED).toEqual({ id: 'CANCELLED', isFinal: true, metadata: null });
+  it('should have the expected states with standard metadata', () => {
+    expect(marketUniversalDef.states.PROPOSED.id).toBe('PROPOSED');
+    expect(marketUniversalDef.states.PROPOSED.isFinal).toBe(false);
+    expect(marketUniversalDef.states.OPEN.isFinal).toBe(false);
+    expect(marketUniversalDef.states.CLOSED.isFinal).toBe(false);
+    expect(marketUniversalDef.states.SETTLED.isFinal).toBe(true);
+    expect(marketUniversalDef.states.CANCELLED.isFinal).toBe(true);
+
+    // States now carry the standard { label, description, category } metadata
+    // block (not null), which survives client/server null-dropping canonicalization.
+    for (const state of Object.values(marketUniversalDef.states)) {
+      expect(state.metadata).not.toBeNull();
+      expect(typeof state.metadata!.label).toBe('string');
+      expect(typeof state.metadata!.description).toBe('string');
+    }
+    expect(marketUniversalDef.states.PROPOSED.metadata!.category).toBe('initial');
+    expect(marketUniversalDef.states.OPEN.metadata!.category).toBe('active');
+    expect(marketUniversalDef.states.SETTLED.metadata!.category).toBe('terminal');
   });
 
   it('should start in PROPOSED state', () => {


### PR DESCRIPTION
Populates standard per-state metadata (label, description, optional category) on the std-app state machines (identity, governance, contracts, markets), so the SDK's std definitions carry human-readable, categorized state info for explorers/UIs.

Independent of the registry type-sync (#181); both branch off main.