### PR TITLE
ci: publish the SDK to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # OIDC trusted publishing to npmjs
 
     steps:
       - name: Checkout
@@ -57,9 +58,10 @@ jobs:
         run: pnpm test
 
       - name: Publish to npmjs.com
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # OIDC trusted publishing: no NODE_AUTH_TOKEN. The job's id-token: write permission plus
+        # the npm-side trusted publisher (repo + this workflow file) authenticate the publish, and
+        # --provenance attaches a signed build-provenance attestation.
+        run: pnpm publish --access public --provenance --no-git-checks
 
       - name: Setup for GitHub Packages
         uses: actions/setup-node@v6


### PR DESCRIPTION
Switches the npmjs publish to OIDC trusted publishing (the package's trusted publisher is now configured on npm), removing the dependency on the long-lived NPM_TOKEN secret that just expired and broke the v2.3.0 publish.

Changes (publish job only):
- add id-token: write permission (required for the OIDC token)
- drop NODE_AUTH_TOKEN: secrets.NPM_TOKEN from the npmjs step (OIDC authenticates instead)
- add --provenance (attaches a signed build-provenance attestation, enabled by OIDC)

The GitHub Packages step is unchanged (still GITHUB_TOKEN).

To re-publish 2.3.0 after merge: run the Publish workflow via workflow_dispatch from main with version 2.3.0 (a plain re-run of the failed run would replay the v2.3.0 tag's OLD workflow). main is already at 2.3.0, so dispatch-from-main publishes the right version.

Caveat to verify on first run: pnpm 10.30 should honor OIDC trusted publishing (pnpm >= 10.16, npm >= 11.5.1). If pnpm's OIDC path doesn't engage, switch just this step to: npm publish --provenance --access public.