### PR TITLE
fix(ci): let OIDC trusted publishing engage on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,19 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Upgrade npm for OIDC trusted publishing
+        # The OIDC -> registry token exchange (trusted publishing) is an npm CLI feature
+        # added in 11.5.1. Node 20 ships npm 10.x, and `pnpm publish` does NOT perform the
+        # exchange at all (it only signs provenance, then errors ENEEDAUTH). So publish with
+        # a recent npm CLI below.
+        run: npm install -g npm@latest
+
       - name: Publish to npmjs.com
-        # OIDC trusted publishing: no NODE_AUTH_TOKEN. The job's id-token: write permission plus
-        # the npm-side trusted publisher (repo + this workflow file) authenticate the publish, and
-        # --provenance attaches a signed build-provenance attestation.
-        run: pnpm publish --access public --provenance --no-git-checks
+        # OIDC trusted publishing: no NODE_AUTH_TOKEN / no .npmrc token. The job's
+        # id-token: write permission plus the npm-side trusted publisher (repo + this workflow
+        # filename) mint a short-lived publish token; --provenance attaches the attestation.
+        # --ignore-scripts skips the `prepare` rebuild (dist already built above).
+        run: npm publish --access public --provenance --ignore-scripts
 
       - name: Setup for GitHub Packages
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,12 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@ottochain'
+          # IMPORTANT: do NOT set registry-url/scope here. Passing registry-url makes
+          # actions/setup-node write a project .npmrc with `_authToken=${NODE_AUTH_TOKEN}`
+          # and default NODE_AUTH_TOKEN to the literal placeholder `XXXXX-XXXXX-XXXXX-XXXXX`.
+          # npm/pnpm then attempt TOKEN auth with that bogus value (404) and never fall back
+          # to OIDC trusted publishing — any configured token suppresses the OIDC exchange.
+          # With no .npmrc token, pnpm publishes to the default npmjs registry via OIDC.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The `Publish` workflow's npmjs step kept failing — first `404`, then `ENEEDAUTH` — even after switching to OIDC trusted publishing and removing `NPM_TOKEN`. Two distinct causes, fixed in two commits:

## 1. Placeholder token suppressed OIDC (the 404)
`Setup Node.js` passed `registry-url: 'https://registry.npmjs.org'`, which makes `actions/setup-node` write a project `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and **default `NODE_AUTH_TOKEN` to the literal placeholder `XXXXX-XXXXX-XXXXX-XXXXX`**. npm then did token auth with that bogus value → `404`, and never fell back to OIDC (any configured token suppresses the exchange). Provenance still signed (separate GitHub-OIDC/sigstore path), which masked the cause.

**Fix:** drop `registry-url`/`scope` from `setup-node` so no token `.npmrc` is written.

## 2. `pnpm publish` doesn't do the OIDC token exchange (the ENEEDAUTH)
With the placeholder gone, `pnpm publish` had no registry auth at all → `ENEEDAUTH`. `pnpm` signs provenance but does **not** perform the npm OIDC→registry token exchange; that is an **npm CLI ≥ 11.5.1** feature, and Node 20 ships npm 10.x.

**Fix:** upgrade npm (`npm install -g npm@latest`) and publish with `npm publish --access public --provenance --ignore-scripts` (dist is already built by the build step; no `workspace:` deps, so npm publish is equivalent). The GitHub Packages step keeps its own `registry-url` + `GITHUB_TOKEN` and is unaffected.

## Verified
Dispatched from this branch → **`+ @ottochain/sdk@2.3.0`** published, `latest`, with a signed provenance attestation, zero tokens. npm now reports `latest = 2.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)