### PR TITLE
refactor: rename oracle API surface to script (paths + types)

### DIFF
--- a/src/ottochain/index.ts
+++ b/src/ottochain/index.ts
@@ -49,7 +49,7 @@ export type {
   // Log entries
   EmittedEvent,
   EventReceipt,
-  OracleInvocation,
+  ScriptInvocation,
   CreationReceipt,
   UpgradeReceipt,
   FiberLogEntry,

--- a/src/ottochain/metagraph-client.ts
+++ b/src/ottochain/metagraph-client.ts
@@ -18,7 +18,7 @@ import type {
   StateMachineFiberRecord,
   ScriptFiberRecord,
   EventReceipt,
-  OracleInvocation,
+  ScriptInvocation,
   FiberStatus,
 } from './types.js';
 import type { CurrencySnapshotResponse } from './snapshot.js';
@@ -185,22 +185,22 @@ export class MetagraphClient {
   }
 
   /**
-   * Get all script oracles, optionally filtered by status.
+   * Get all scripts, optionally filtered by status.
    */
   async getScripts(status?: FiberStatus): Promise<Record<string, ScriptFiberRecord>> {
     const query = status ? `?status=${status}` : '';
     return this.ml0.get<Record<string, ScriptFiberRecord>>(
-      `/data-application/v1/oracles${query}`
+      `/data-application/v1/scripts${query}`
     );
   }
 
   /**
-   * Get a single script oracle by fiber ID.
+   * Get a single script by fiber ID.
    */
   async getScript(scriptId: string): Promise<ScriptFiberRecord | null> {
     try {
       return await this.ml0.get<ScriptFiberRecord>(
-        `/data-application/v1/oracles/${scriptId}`
+        `/data-application/v1/scripts/${scriptId}`
       );
     } catch (error) {
       if (error instanceof NetworkError && error.statusCode === 404) {
@@ -211,11 +211,11 @@ export class MetagraphClient {
   }
 
   /**
-   * Get oracle invocations from the current ordinal's logs.
+   * Get script invocations from the current ordinal's logs.
    */
-  async getScriptInvocations(scriptId: string): Promise<OracleInvocation[]> {
-    return this.ml0.get<OracleInvocation[]>(
-      `/data-application/v1/oracles/${scriptId}/invocations`
+  async getScriptInvocations(scriptId: string): Promise<ScriptInvocation[]> {
+    return this.ml0.get<ScriptInvocation[]>(
+      `/data-application/v1/scripts/${scriptId}/invocations`
     );
   }
 

--- a/src/ottochain/snapshot.ts
+++ b/src/ottochain/snapshot.ts
@@ -11,7 +11,7 @@
  */
 
 import { HttpClient } from '@constellation-network/metagraph-sdk/network';
-import type { OnChain, EventReceipt, OracleInvocation, FiberLogEntry } from './types.js';
+import type { OnChain, EventReceipt, ScriptInvocation, FiberLogEntry } from './types.js';
 
 /**
  * Decode on-chain state from binary (JsonBinaryCodec format).
@@ -104,7 +104,7 @@ export function getLogsForFiber(onChain: OnChain, fiberId: string): FiberLogEntr
 /**
  * Get EventReceipt log entries for a specific fiber.
  *
- * EventReceipts are distinguished from OracleInvocations by the presence
+ * EventReceipts are distinguished from ScriptInvocations by the presence
  * of the `eventName` field.
  *
  * @param onChain - Decoded on-chain state
@@ -117,16 +117,16 @@ export function getEventReceipts(onChain: OnChain, fiberId: string): EventReceip
 }
 
 /**
- * Get OracleInvocation log entries for a specific fiber.
+ * Get ScriptInvocation log entries for a specific fiber.
  *
- * OracleInvocations are distinguished from EventReceipts by the presence
+ * ScriptInvocations are distinguished from EventReceipts by the presence
  * of the `method` field.
  *
  * @param onChain - Decoded on-chain state
  * @param fiberId - Fiber UUID to filter by
- * @returns Array of OracleInvocation entries
+ * @returns Array of ScriptInvocation entries
  */
-export function getScriptInvocations(onChain: OnChain, fiberId: string): OracleInvocation[] {
+export function getScriptInvocations(onChain: OnChain, fiberId: string): ScriptInvocation[] {
   return getLogsForFiber(onChain, fiberId)
-    .filter((entry): entry is OracleInvocation => 'method' in entry && 'result' in entry);
+    .filter((entry): entry is ScriptInvocation => 'method' in entry && 'result' in entry);
 }

--- a/src/ottochain/types.ts
+++ b/src/ottochain/types.ts
@@ -51,7 +51,7 @@ export type FiberStatus = 'Active' | 'Archived' | 'Failed';
 // ---------------------------------------------------------------------------
 
 /**
- * Access control policy for script oracles.
+ * Access control policy for scripts.
  * Wire format: discriminated union with type key.
  */
 export type AccessControlPolicy =
@@ -281,9 +281,9 @@ export interface EventReceipt {
 }
 
 /**
- * Log entry for a script oracle invocation.
+ * Log entry for a script invocation.
  */
-export interface OracleInvocation {
+export interface ScriptInvocation {
   fiberId: string;
   method: string;
   args: JsonLogicValue;
@@ -328,7 +328,7 @@ export interface UpgradeReceipt {
 /**
  * Union type for all fiber log entries.
  */
-export type FiberLogEntry = EventReceipt | OracleInvocation | CreationReceipt | UpgradeReceipt;
+export type FiberLogEntry = EventReceipt | ScriptInvocation | CreationReceipt | UpgradeReceipt;
 
 // ---------------------------------------------------------------------------
 // Fiber records
@@ -358,7 +358,7 @@ export interface StateMachineFiberRecord {
 }
 
 /**
- * On-chain record for a script oracle fiber.
+ * On-chain record for a script fiber.
  */
 export interface ScriptFiberRecord {
   fiberId: string;
@@ -371,7 +371,7 @@ export interface ScriptFiberRecord {
   sequenceNumber: number;
   owners: string[];  // Plain string array
   status: FiberStatus;
-  lastInvocation?: OracleInvocation;
+  lastInvocation?: ScriptInvocation;
 }
 
 /**
@@ -458,7 +458,7 @@ export interface ArchiveStateMachine {
 }
 
 /**
- * Create a new script oracle fiber.
+ * Create a new script fiber.
  */
 export interface CreateScript {
   fiberId: string;
@@ -468,7 +468,7 @@ export interface CreateScript {
 }
 
 /**
- * Invoke a script oracle.
+ * Invoke a script script.
  */
 export interface InvokeScript {
   fiberId: string;

--- a/tests/ottochain-client.test.ts
+++ b/tests/ottochain-client.test.ts
@@ -134,13 +134,13 @@ describe('MetagraphClient', () => {
       mockMl0Get.mockResolvedValue(scripts);
       const result = await client.getScripts();
       expect(result).toEqual(scripts);
-      expect(mockMl0Get).toHaveBeenCalledWith('/data-application/v1/oracles');
+      expect(mockMl0Get).toHaveBeenCalledWith('/data-application/v1/scripts');
     });
 
     it('fetches scripts with status filter', async () => {
       mockMl0Get.mockResolvedValue({});
       await client.getScripts('Active' as any);
-      expect(mockMl0Get).toHaveBeenCalledWith('/data-application/v1/oracles?status=Active');
+      expect(mockMl0Get).toHaveBeenCalledWith('/data-application/v1/scripts?status=Active');
     });
   });
 
@@ -150,7 +150,7 @@ describe('MetagraphClient', () => {
       mockMl0Get.mockResolvedValue(invocations);
       const result = await client.getScriptInvocations('s1');
       expect(result).toEqual(invocations);
-      expect(mockMl0Get).toHaveBeenCalledWith('/data-application/v1/oracles/s1/invocations');
+      expect(mockMl0Get).toHaveBeenCalledWith('/data-application/v1/scripts/s1/invocations');
     });
   });
 
@@ -248,7 +248,7 @@ describe('Snapshot utilities', () => {
     success: true,
   };
 
-  const mockOracleInvocation = {
+  const mockScriptInvocation = {
     fiberId: 'fiber-1',
     method: 'evaluate',
     args: { x: 1 },
@@ -258,7 +258,7 @@ describe('Snapshot utilities', () => {
 
   const mockOnChain = {
     latestLogs: {
-      'fiber-1': [mockEventReceipt, mockOracleInvocation],
+      'fiber-1': [mockEventReceipt, mockScriptInvocation],
     },
     stateMachineFibers: {},
     scriptFibers: {},
@@ -314,7 +314,7 @@ describe('Snapshot utilities', () => {
   });
 
   describe('getScriptInvocations', () => {
-    it('filters to OracleInvocation entries only', () => {
+    it('filters to ScriptInvocation entries only', () => {
       const invocations = getScriptInvocations(mockOnChain as any, 'fiber-1');
       expect(invocations).toHaveLength(1);
       expect(invocations[0].method).toBe('evaluate');


### PR DESCRIPTION
Aligns the SDK with the ottochain script-only API migration. **Sister PR:** scasplte2/ottochain#165.

### Changes
- **`MetagraphClient`**: `/data-application/v1/oracles{,/{id},/{id}/invocations}` → `/scripts`. `listScripts` / `getScript` / `getScriptInvocations` now hit the renamed chain routes.
- **`types.ts`**: `OracleInvocation` → `ScriptInvocation` (the `FiberLogEntry` union + `ScriptFiberRecord.lastInvocation`); re-export (`index.ts`) and `snapshot.ts` helper types updated. `getScriptInvocations` is unchanged (it filters structurally on `method`/`result`).

### Deliberately preserved (real-world domain, **not** our terminology)
- The **identity app's** `"oracle"` role/state and the **prediction-market** resolution oracle (generated proto + app state machines). `src/generated/**` untouched.

### Validation
- `tsc` type-check clean; **1126** Jest tests pass (49 suites).

The chain side (PR #165) emits `ScriptInvocation` and serves `/v1/scripts`. ottochain's e2e does not depend on this PR (it uses direct HTTP), so the two can merge in either order; this keeps downstream SDK consumers aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)