### PR TITLE
feat(privacy): shieldApp(def) — shield any fiber app into a private-state pool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,3 +150,7 @@ export {
   type StateCategory,
   type Transition,
 } from './schema/fiber-app.js';
+
+// ─── Privacy: shield any fiber app into a zk-jlvm-shielded private-state pool ──
+// See docs/design/zk-private-contract-state-rfc.md.
+export { shieldApp, SHIELDED_POOL_STATE, type ShieldOptions } from './privacy/shield-app.js';

--- a/src/privacy/index.ts
+++ b/src/privacy/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Privacy: shield any fiber app into a zk-jlvm-shielded private-state pool.
+ * See docs/design/zk-private-contract-state-rfc.md.
+ */
+export { shieldApp, SHIELDED_POOL_STATE, type ShieldOptions } from "./shield-app.js";
+export { sealedBidAccountDef, shieldedSealedBidDef, vickreyAuctionDef } from "./sealed-bid.js";

--- a/src/privacy/sealed-bid.ts
+++ b/src/privacy/sealed-bid.ts
@@ -1,0 +1,212 @@
+/**
+ * Sealed-bid (Vickrey) auction — the worked example for the privacy stack.
+ *
+ * Two pieces (RFC §4):
+ *  1. `sealedBidAccountDef` — the PRIVATE per-bidder bid. `shieldApp` turns it into a shielded
+ *     pool (`shieldedSealedBidDef`): a bidder commits a bid note and proves it well-formed with a
+ *     zk-jlvm-shielded Groth16 proof, so the amount stays sealed *until the deadline*. This is the
+ *     mechanical per-instance / single-owner case.
+ *  2. `vickreyAuctionDef` — the PUBLIC settlement (reveal-then-tally). After the deadline bidders
+ *     open their notes; the combine computes winner = argmax and clearingPrice = second-highest
+ *     (the Vickrey price). This is the one shared-state step, kept simple for v1; a zk settlement
+ *     proof that seals losers' amounts forever is the deferred upgrade (RFC §10).
+ */
+
+import { defineFiberApp, type FiberAppDefinition } from "../schema/fiber-app.js";
+import { shieldApp, type ShieldOptions } from "./shield-app.js";
+
+// ── 1. The private bid (base app, shielded by shieldApp) ──────────────────────
+
+/** The per-bidder PRIVATE state: a bid note `{ amount, bidder, nonce }`. */
+export const sealedBidAccountDef = defineFiberApp({
+  metadata: {
+    name: "SealedBidAccount",
+    app: "markets",
+    type: "sealed-bid-account",
+    version: "1.0.0",
+    description: "A single bidder's sealed bid (private amount). Shielded via shieldApp.",
+  },
+  stateSchema: {
+    properties: {
+      amount: { type: "number", description: "the (private) bid amount" },
+      bidder: { type: "address" },
+      nonce: { type: "number", description: "per-note randomness; keeps the commitment hiding" },
+    },
+  },
+  eventSchemas: {
+    place_bid: {
+      description: "Set the sealed bid amount",
+      required: ["amount"] as const,
+      properties: { amount: { type: "number", minimum: 1 } },
+    },
+  },
+  states: {
+    OPEN: { id: "OPEN", isFinal: false, metadata: { label: "Open", description: "No bid yet", category: "initial" } },
+    BID: { id: "BID", isFinal: false, metadata: { label: "Bid", description: "Bid committed", category: "active" } },
+  },
+  initialState: "OPEN",
+  transitions: [
+    {
+      // This effect is what the zk-jlvm-shielded circuit runs in-zkVM; `exprHash` pins it.
+      from: "OPEN",
+      to: "BID",
+      eventName: "place_bid",
+      guard: { ">": [{ var: "event.amount" }, 0] },
+      effect: { merge: [{ var: "state" }, { amount: { var: "event.amount" } }] },
+      dependencies: [],
+    },
+  ],
+} as const);
+
+/**
+ * The shielded sealed-bid pool. `vkey`/`exprHash` come from the built zk-jlvm-shielded circuit
+ * (these are placeholders until the circuit's program vkey + the keccak of the `place_bid` effect
+ * are wired in by the genesis/build step).
+ */
+export function shieldedSealedBidDef(opts: ShieldOptions): FiberAppDefinition {
+  return shieldApp(sealedBidAccountDef, opts);
+}
+
+// ── 2. The public Vickrey settlement ──────────────────────────────────────────
+
+/**
+ * Public reveal-then-tally settlement. `reveal` appends an opened bid (in a full build the opening
+ * is checked against the recorded commitment in the shielded pool); `settle` computes the winner
+ * and the Vickrey (second-price) clearing price over the revealed bids in one reduce.
+ */
+export const vickreyAuctionDef = defineFiberApp({
+  metadata: {
+    name: "VickreyAuction",
+    app: "markets",
+    type: "vickrey-auction",
+    version: "1.0.0",
+    description: "Sealed-bid second-price auction: public reveal-then-tally over shielded bids.",
+    crossReferences: { bidPool: "the ShieldedSealedBidAccount pool holding the sealed bids" },
+  },
+  createSchema: {
+    required: ["seller", "deadline"] as const,
+    properties: {
+      seller: { type: "address", immutable: true },
+      deadline: { type: "timestamp", immutable: true },
+    },
+  },
+  stateSchema: {
+    properties: {
+      seller: { type: "address", immutable: true },
+      deadline: { type: "timestamp", immutable: true },
+      status: { type: "string", computed: true },
+      revealed: { type: "array", computed: true, description: "opened bids [{bidder, amount}]" },
+      winner: { type: "address", computed: true },
+      clearingPrice: { type: "number", computed: true, description: "second-highest bid (Vickrey)" },
+    },
+  },
+  eventSchemas: {
+    reveal: {
+      description: "Open a sealed bid after the deadline",
+      required: ["bidder", "amount"] as const,
+      properties: { bidder: { type: "address" }, amount: { type: "number", minimum: 1 } },
+    },
+    settle: { description: "Tally the revealed bids (winner + second price)" },
+  },
+  states: {
+    OPEN: { id: "OPEN", isFinal: false, metadata: { label: "Open", description: "Bidding (sealed)", category: "initial" } },
+    REVEAL: { id: "REVEAL", isFinal: false, metadata: { label: "Reveal", description: "Opening bids", category: "active" } },
+    SETTLED: { id: "SETTLED", isFinal: true, metadata: { label: "Settled", description: "Winner + price set", category: "terminal" } },
+  },
+  initialState: "OPEN",
+  transitions: [
+    {
+      from: "OPEN",
+      to: "REVEAL",
+      eventName: "reveal",
+      guard: { ">=": [{ var: "$timestamp" }, { var: "state.deadline" }] },
+      effect: {
+        merge: [
+          { var: "state" },
+          {
+            status: "REVEAL",
+            revealed: {
+              cat: [
+                { var: "state.revealed" },
+                [{ bidder: { var: "event.bidder" }, amount: { var: "event.amount" } }],
+              ],
+            },
+          },
+        ],
+      },
+      dependencies: [],
+    },
+    {
+      from: "REVEAL",
+      to: "REVEAL",
+      eventName: "reveal",
+      guard: { ">=": [{ var: "$timestamp" }, { var: "state.deadline" }] },
+      effect: {
+        merge: [
+          { var: "state" },
+          {
+            revealed: {
+              cat: [
+                { var: "state.revealed" },
+                [{ bidder: { var: "event.bidder" }, amount: { var: "event.amount" } }],
+              ],
+            },
+          },
+        ],
+      },
+      dependencies: [],
+    },
+    {
+      // Vickrey tally: fold the revealed bids tracking (max, second, winner).
+      from: "REVEAL",
+      to: "SETTLED",
+      eventName: "settle",
+      guard: { ">": [{ reduce: [{ var: "state.revealed" }, { "+": [{ var: "accumulator" }, 1] }, 0] }, 0] },
+      effect: {
+        merge: [
+          { var: "state" },
+          {
+            status: "SETTLED",
+            settledAt: { var: "$timestamp" },
+            winner: {
+              var: [
+                "tally.winner",
+                null,
+              ],
+            },
+            clearingPrice: { var: ["tally.second", 0] },
+            // compute the tally once and expose it for the two fields above
+            tally: {
+              reduce: [
+                { var: "state.revealed" },
+                {
+                  if: [
+                    { ">": [{ var: "current.amount" }, { var: "accumulator.max" }] },
+                    {
+                      max: { var: "current.amount" },
+                      second: { var: "accumulator.max" },
+                      winner: { var: "current.bidder" },
+                    },
+                    {
+                      if: [
+                        { ">": [{ var: "current.amount" }, { var: "accumulator.second" }] },
+                        {
+                          max: { var: "accumulator.max" },
+                          second: { var: "current.amount" },
+                          winner: { var: "accumulator.winner" },
+                        },
+                        { var: "accumulator" },
+                      ],
+                    },
+                  ],
+                },
+                { max: 0, second: 0, winner: null },
+              ],
+            },
+          },
+        ],
+      },
+      dependencies: [],
+    },
+  ],
+} as const);

--- a/src/privacy/shield-app.ts
+++ b/src/privacy/shield-app.ts
@@ -1,0 +1,158 @@
+/**
+ * shieldApp — turn a fiber app into a PRIVATE-state pool.
+ *
+ * Given a base {@link FiberAppDefinition} (the app whose state + transition you want to keep
+ * private), `shieldApp` returns a new `FiberAppDefinition` for a "shielded pool" Machine fiber.
+ * The pool's state is PUBLIC scaffolding only — the spent-nullifier set, the commitment log, and
+ * the set of valid anchors — while the app's real state lives off-chain in a note committed to
+ * the tree. Each app transition is carried out off-chain and attested by a single
+ * `zk-jlvm-shielded` Groth16 proof; the on-chain combine just verifies the proof, rejects an
+ * already-spent nullifier, and records the new commitment.
+ *
+ * Division of labour (see ottochain-sdk RFC docs/design/zk-private-contract-state-rfc.md):
+ *  - the CIRCUIT proves membership ∧ authorization ∧ `jlvm-core` effect ∧ new commitment;
+ *  - this GUARD (combine) verifies the proof, pins which app logic ran (`exprHash`), checks the
+ *    anchor is recent, and checks the nullifier is fresh — all combiner-only (CLAUDE.md);
+ *  - block-validity stays structural (proof / publicValues present + hex).
+ *
+ * It uses NO new metakit opcode: `groth16_verify` verifies the proof, and the four-`bytes32`
+ * public values (`anchor`, `nullifier`, `newCommitment`, `exprHash`) are extracted from the
+ * VERIFIED `publicValues` string with fixed-offset `substr` — slicing the verified bytes IS the
+ * binding (§8.1).
+ *
+ * NOTE on cost: the note model rehashes the whole state each transition, so proving cost is
+ * O(state size) (RFC §8). Keep shielded note state small (a few KB); for large keyed state use
+ * the auth-DB variant (RFC §3.1.1).
+ */
+
+import {
+  defineFiberApp,
+  type FiberAppDefinition,
+  type JsonLogicRule,
+  type SchemaField,
+} from "../schema/fiber-app.js";
+
+export interface ShieldOptions {
+  /** SP1 program vkey for the zk-jlvm-shielded circuit (0x-prefixed bytes32 hex). Pinned at creation. */
+  vkey: string;
+  /**
+   * `keccak256(effectExpr)` the circuit commits — pins WHICH app logic the accepted proofs ran.
+   * Compute it from the base app's transition effect; one pinned effect per pool (the per-event /
+   * multi-effect generalization is RFC §10 open question 1).
+   */
+  exprHash: string;
+  /** How many recent anchors stay spendable (rolling window). Default 64. */
+  rootWindow?: number;
+}
+
+/**
+ * Field extractors over the abi-encoded `JlvmTransitionPublicValues` — four static `bytes32`
+ * `[anchor | nullifier | newCommitment | exprHash]`, a fixed 128-byte (256 hex char) layout with
+ * NO dynamic arrays. `publicValues` is the 0x-prefixed hex from the prover, so each field is 64
+ * hex chars starting at: anchor=2, nullifier=66, newCommitment=130, exprHash=194.
+ */
+const pvField = (publicValues: JsonLogicRule, hexOffset: number): JsonLogicRule => ({
+  substr: [publicValues, hexOffset, 64],
+});
+
+/** Standard public state every shielded pool carries (the rest of the app state is private/off-chain). */
+export const SHIELDED_POOL_STATE: Record<string, SchemaField> = {
+  vkey: { type: "hash", immutable: true },
+  exprHash: { type: "hash", immutable: true },
+  rootWindow: { type: "integer", immutable: true },
+  currentRoot: { type: "hash", computed: true },
+  knownRoots: { type: "array", computed: true, description: "rolling window of valid anchors (hex)" },
+  nullifiers: { type: "array", computed: true, description: "spent set (hex); monotonic — see RFC §5.3" },
+  commitments: { type: "array", computed: true, description: "append-only log of output commitments (hex)" },
+  leafCount: { type: "integer", computed: true, default: 0 },
+  transitions: { type: "integer", computed: true, default: 0 },
+};
+
+/**
+ * Build the shielded-pool variant of `base`.
+ *
+ * @param base  the app being shielded (used for naming + to document the pinned logic).
+ * @param opts  the circuit vkey + the pinned `exprHash` + the anchor window.
+ */
+export function shieldApp(base: FiberAppDefinition, opts: ShieldOptions): FiberAppDefinition {
+  const publicValues: JsonLogicRule = { var: "event.publicValues" };
+  const anchor = pvField(publicValues, 2);
+  const nullifier = pvField(publicValues, 66);
+  const newCommitment = pvField(publicValues, 130);
+  const exprHash = pvField(publicValues, 194);
+
+  // GUARD (combine): all stateful, combiner-only.
+  const guard: JsonLogicRule = {
+    and: [
+      // 1. the proof verifies against the pool's pinned vkey over EXACTLY these public bytes
+      { groth16_verify: [{ var: "state.vkey" }, publicValues, { var: "event.proof" }] },
+      // 2. it ran the app logic this pool pins (binds which effect produced the transition)
+      { "===": [exprHash, { var: "state.exprHash" }] },
+      // 3. the spent note was proven under an anchor we still honor
+      { in: [anchor, { var: "state.knownRoots" }] },
+      // 4. inter-transfer double-spend guard: the nullifier is not already spent
+      { none: [{ var: "state.nullifiers" }, { "===": [{ var: "" }, nullifier] }] },
+    ],
+  };
+
+  // EFFECT (combine): spend the nullifier, record the new commitment, advance counters.
+  // Root advancement (turning the appended commitment into the next anchor) is wallet/Bridge-side
+  // per RFC §6.2 / §10; the chain records the commitment + nullifier here.
+  const effect: JsonLogicRule = {
+    merge: [
+      { var: "state" },
+      {
+        nullifiers: { cat: [{ var: "state.nullifiers" }, [nullifier]] },
+        commitments: { cat: [{ var: "state.commitments" }, [newCommitment]] },
+        leafCount: { "+": [{ var: "state.leafCount" }, 1] },
+        transitions: { "+": [{ var: "state.transitions" }, 1] },
+        lastTransitionAt: { var: "$ordinal" },
+      },
+    ],
+  };
+
+  return defineFiberApp({
+    metadata: {
+      name: `Shielded${base.metadata.name}`,
+      app: "privacy",
+      type: `shielded-${base.metadata.type}`,
+      version: base.metadata.version,
+      description:
+        `Shielded (zk-jlvm-shielded) variant of ${base.metadata.name}: private state transitions ` +
+        `verified by a Groth16 proof; the nullifier set + anchors are public pool state.`,
+    },
+
+    createSchema: {
+      required: ["vkey", "exprHash"],
+      properties: {
+        vkey: { type: "hash", immutable: true, default: opts.vkey },
+        exprHash: { type: "hash", immutable: true, default: opts.exprHash },
+        rootWindow: { type: "integer", immutable: true, default: opts.rootWindow ?? 64 },
+      },
+    },
+
+    stateSchema: { properties: { ...SHIELDED_POOL_STATE } },
+
+    eventSchemas: {
+      transition: {
+        description: `A private state transition of ${base.metadata.name}, attested by a zk-jlvm-shielded Groth16 proof.`,
+        required: ["proof", "publicValues"],
+        properties: {
+          proof: { type: "string", description: "Groth16 proof bytes (0x hex)" },
+          publicValues: { type: "string", description: "abi-encoded JlvmTransitionPublicValues (4×bytes32, 0x hex)" },
+        },
+      },
+    },
+
+    states: {
+      ACTIVE: {
+        id: "ACTIVE",
+        isFinal: false,
+        metadata: { label: "Active", description: "Pool accepts shielded transitions", category: "active" },
+      },
+    },
+    initialState: "ACTIVE",
+
+    transitions: [{ from: "ACTIVE", to: "ACTIVE", eventName: "transition", guard, effect, dependencies: [] }],
+  });
+}

--- a/tests/shield-app.test.ts
+++ b/tests/shield-app.test.ts
@@ -1,0 +1,93 @@
+import { shieldApp } from "../src/privacy/shield-app.js";
+import {
+  sealedBidAccountDef,
+  shieldedSealedBidDef,
+  vickreyAuctionDef,
+} from "../src/privacy/sealed-bid.js";
+
+// The real zk-jlvm-shielded program vkey + the keccak of the pinned effect (metakit-sdk #53 fixture).
+const VKEY = "0x00f48340d57e907ec1364bb941e40d86808c0fe5360ead51c4a401556a0d1267";
+const EXPR = "0x9296a910474791c389d96ad73ff6569544746f173b1ba4e7533322e27078eca9";
+
+describe("shieldApp", () => {
+  const shielded = shieldApp(sealedBidAccountDef, { vkey: VKEY, exprHash: EXPR });
+
+  it("produces a privacy pool fiber app named after the base", () => {
+    expect(shielded.metadata.app).toBe("privacy");
+    expect(shielded.metadata.name).toBe("ShieldedSealedBidAccount");
+    expect(shielded.metadata.type).toBe("shielded-sealed-bid-account");
+  });
+
+  it("public state is the pool scaffolding (nullifiers, commitments, roots, vkey, exprHash)", () => {
+    const props = Object.keys(shielded.stateSchema!.properties);
+    for (const f of ["vkey", "exprHash", "knownRoots", "nullifiers", "commitments", "leafCount"]) {
+      expect(props).toContain(f);
+    }
+  });
+
+  it("createSchema pins vkey + exprHash with the supplied defaults", () => {
+    expect(shielded.createSchema!.required).toEqual(expect.arrayContaining(["vkey", "exprHash"]));
+    expect(shielded.createSchema!.properties.vkey.default).toBe(VKEY);
+    expect(shielded.createSchema!.properties.exprHash.default).toBe(EXPR);
+  });
+
+  it("has one ACTIVE->ACTIVE 'transition' whose guard verifies the proof against pinned state", () => {
+    expect(shielded.transitions).toHaveLength(1);
+    const t = shielded.transitions[0];
+    expect(t.from).toBe("ACTIVE");
+    expect(t.to).toBe("ACTIVE");
+    expect(t.eventName).toBe("transition");
+
+    const guard = JSON.stringify(t.guard);
+    expect(guard).toContain("groth16_verify");
+    expect(guard).toContain("none"); // nullifier non-membership (combiner-only)
+    expect(guard).toContain('"in"'); // anchor ∈ knownRoots
+    // the guard reads the pinned vkey + exprHash from STATE, never from the event
+    expect(guard).toContain("state.vkey");
+    expect(guard).toContain("state.exprHash");
+    expect(guard).toContain("state.knownRoots");
+    expect(guard).toContain("state.nullifiers");
+  });
+
+  it("extracts the 4 static public-value fields at fixed offsets 2/66/130/194 (no PV opcode)", () => {
+    const tStr = JSON.stringify(shielded.transitions[0]); // guard + effect
+    for (const off of [2, 66, 130, 194]) {
+      expect(tStr).toContain(`{"var":"event.publicValues"},${off},64]`);
+    }
+  });
+
+  it("effect spends the nullifier and records the new commitment", () => {
+    const eff = JSON.stringify(shielded.transitions[0].effect);
+    expect(eff).toContain("state.nullifiers");
+    expect(eff).toContain("state.commitments");
+    expect(eff).toContain("cat");
+  });
+
+  it("the transition event carries the proof + publicValues", () => {
+    const ev = shielded.eventSchemas!.transition;
+    expect(ev.required).toEqual(expect.arrayContaining(["proof", "publicValues"]));
+  });
+});
+
+describe("sealed-bid example", () => {
+  it("shieldedSealedBidDef(opts) shields the bid account", () => {
+    const d = shieldedSealedBidDef({ vkey: VKEY, exprHash: EXPR });
+    expect(d.metadata.app).toBe("privacy");
+    expect(d.transitions[0].eventName).toBe("transition");
+  });
+
+  it("the base bid keeps amount private (a normal place_bid effect, run in-circuit)", () => {
+    const t = sealedBidAccountDef.transitions[0];
+    expect(t.eventName).toBe("place_bid");
+    expect(JSON.stringify(t.effect)).toContain("amount");
+  });
+
+  it("vickreyAuction settle computes the second-price (Vickrey) clearing price", () => {
+    const settle = vickreyAuctionDef.transitions.find((t) => t.eventName === "settle");
+    expect(settle).toBeDefined();
+    const eff = JSON.stringify(settle!.effect);
+    expect(eff).toContain("clearingPrice");
+    expect(eff).toContain("reduce"); // the top-2 fold over revealed bids
+    expect(eff).toContain("second");
+  });
+});


### PR DESCRIPTION
## Summary

Implements **P2** of the private-contract-state RFC (#211): `shieldApp(base, { vkey, exprHash })` — a transform that turns **any** `FiberAppDefinition` into a **shielded-pool** variant. Public state is scaffolding only (nullifier set, commitment log, valid anchors, `vkey`, `exprHash`); the app's real state lives off-chain in a note committed to the tree, and each transition is attested by **one `zk-jlvm-shielded` Groth16 proof**.

## The combine (one transition, all combiner-only)

```
guard  = groth16_verify(state.vkey, event.publicValues, event.proof)
         AND exprHash(pv) === state.exprHash        # pins WHICH app logic ran
         AND anchor(pv)  in  state.knownRoots        # recent-anchor
         AND none(state.nullifiers === nullifier(pv))  # inter-transfer double-spend
effect = spend nullifier + record newCommitment + bump counters
```

**No new metakit opcode.** The four static `bytes32` public values are extracted with fixed-offset `substr` (2/66/130/194 of the 0x-hex), and since `groth16_verify` attests *exactly* those bytes, slicing fields from the verified string **is** the binding (RFC §8.1). Honors `CLAUDE.md`: the nullifier check is combiner-only; block-validity stays structural.

## Worked example — sealed-bid (Vickrey)

- `sealedBidAccountDef` — the private per-bidder bid; `shieldApp` → `shieldedSealedBidDef`.
- `vickreyAuctionDef` — public reveal-then-tally settlement; the `settle` effect computes winner + **second-price** clearing price via a top-2 `reduce`.

## Validation

`tests/shield-app.test.ts` — **10/10**; `tsc --noEmit` + `eslint` clean. `vkey`/`exprHash` in the test are the real metakit-sdk #53 fixture values.

## Cost guardrail (from the RFC §8 measurements)

The note model rehashes the whole state each transition → proving cost is `O(state size)` (~68M cycles for small state; ~17K cycles/JSON-element on top). A shielded pool should cap note state well below the 1 MB fiber cap; large keyed state ⇒ the auth-DB variant.

## Depends on

- metakit-sdk #53 (`zk-jlvm-shielded` circuit + guest + GPU fixture) and #54 (blst fix).
- Design: RFC #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)