### PR TITLE
feat: typed domain schemas from the metagraph contract

### DIFF
--- a/openapi/ottochain-openapi.json
+++ b/openapi/ottochain-openapi.json
@@ -77,11 +77,11 @@
         "operationId" : "getData-applicationV1Onchain",
         "responses" : {
           "200" : {
-            "description" : "OnChain",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/OnChain"
                 }
               }
             }
@@ -98,11 +98,11 @@
         "operationId" : "getData-applicationV1Checkpoint",
         "responses" : {
           "200" : {
-            "description" : "Checkpoint[CalculatedState]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/Checkpoint_CalculatedState"
                 }
               }
             }
@@ -130,11 +130,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "SortedMap[UUID, StateMachineFiberRecord]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/Map_V"
                 }
               }
             }
@@ -172,11 +172,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "Option[StateMachineFiberRecord]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/StateMachineFiberRecord"
                 }
               }
             }
@@ -214,11 +214,14 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "List[EventReceipt]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/EventReceipt"
+                  }
                 }
               }
             }
@@ -357,11 +360,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "StateProofResponse",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/StateProofResponse"
                 }
               }
             }
@@ -399,11 +402,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "SortedMap[UUID, ScriptFiberRecord]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/Map_V"
                 }
               }
             }
@@ -441,11 +444,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "Option[ScriptFiberRecord]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/ScriptFiberRecord"
                 }
               }
             }
@@ -483,11 +486,14 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "List[ScriptInvocation]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ScriptInvocation"
+                  }
                 }
               }
             }
@@ -576,11 +582,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "StateProofResponse",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/StateProofResponse"
                 }
               }
             }
@@ -627,11 +633,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "StateProofResponse",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/StateProofResponse"
                 }
               }
             }
@@ -658,11 +664,11 @@
         "operationId" : "getData-applicationV1Registry",
         "responses" : {
           "200" : {
-            "description" : "SortedMap[RegistryName, RegistryEntry]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/Map_V"
                 }
               }
             }
@@ -690,11 +696,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "Option[RegistryName]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "type" : "string"
                 }
               }
             }
@@ -731,11 +737,11 @@
         ],
         "responses" : {
           "200" : {
-            "description" : "Option[RegistryEntry]",
+            "description" : "",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  
+                  "$ref" : "#/components/schemas/RegistryEntry"
                 }
               }
             }
@@ -832,6 +838,355 @@
   },
   "components" : {
     "schemas" : {
+      "AssetCommit" : {
+        "title" : "AssetCommit",
+        "type" : "object",
+        "required" : [
+          "behavior",
+          "sequenceNumber",
+          "recordHash"
+        ],
+        "properties" : {
+          "behavior" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "recordHash" : {
+            "type" : "string"
+          },
+          "origin" : {
+            "type" : "string"
+          }
+        }
+      },
+      "AssetRecord" : {
+        "title" : "AssetRecord",
+        "type" : "object",
+        "required" : [
+          "assetId",
+          "schemaBinding",
+          "behavior",
+          "holder",
+          "amount",
+          "sequenceNumber",
+          "creationOrdinal",
+          "latestUpdateOrdinal"
+        ],
+        "properties" : {
+          "assetId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "schemaBinding" : {
+            "$ref" : "#/components/schemas/SchemaBinding"
+          },
+          "behavior" : {
+            "$ref" : "#/components/schemas/TokenBehavior"
+          },
+          "holder" : {
+            
+          },
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "creationOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "latestUpdateOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "expiresAt" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "componentFiberIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
+          },
+          "componentsCommitment" : {
+            "type" : "string"
+          },
+          "parentCompositeId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "provenance" : {
+            "$ref" : "#/components/schemas/OriginProvenance"
+          }
+        }
+      },
+      "CalculatedState" : {
+        "title" : "CalculatedState",
+        "type" : "object",
+        "required" : [
+          "stateMachines",
+          "scripts",
+          "registry",
+          "reverseNames",
+          "assets",
+          "usedNonces"
+        ],
+        "properties" : {
+          "stateMachines" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "scripts" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "registry" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "reverseNames" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "assets" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "usedNonces" : {
+            "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "Checkpoint_CalculatedState" : {
+        "title" : "Checkpoint_CalculatedState",
+        "type" : "object",
+        "required" : [
+          "ordinal",
+          "state"
+        ],
+        "properties" : {
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "state" : {
+            "$ref" : "#/components/schemas/CalculatedState"
+          }
+        }
+      },
+      "EmittedEvent" : {
+        "title" : "EmittedEvent",
+        "type" : "object",
+        "required" : [
+          "name",
+          "data"
+        ],
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "data" : {
+            
+          },
+          "destination" : {
+            "type" : "string"
+          }
+        }
+      },
+      "EventReceipt" : {
+        "title" : "EventReceipt",
+        "type" : "object",
+        "required" : [
+          "fiberId",
+          "sequenceNumber",
+          "eventName",
+          "ordinal",
+          "fromState",
+          "toState",
+          "success",
+          "gasUsed",
+          "triggersFired"
+        ],
+        "properties" : {
+          "fiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "eventName" : {
+            "type" : "string"
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "fromState" : {
+            "type" : "string"
+          },
+          "toState" : {
+            "type" : "string"
+          },
+          "success" : {
+            "type" : "boolean"
+          },
+          "gasUsed" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "triggersFired" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "errorMessage" : {
+            "type" : "string"
+          },
+          "sourceFiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "emittedEvents" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/EmittedEvent"
+            }
+          }
+        }
+      },
+      "FiberCommit" : {
+        "title" : "FiberCommit",
+        "type" : "object",
+        "required" : [
+          "recordHash",
+          "sequenceNumber"
+        ],
+        "properties" : {
+          "recordHash" : {
+            "type" : "string"
+          },
+          "stateDataHash" : {
+            "type" : "string"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
+      "Map_V" : {
+        "title" : "Map_V",
+        "type" : "object",
+        "additionalProperties" : {
+          "$ref" : "#/components/schemas/FiberCommit"
+        }
+      },
+      "OnChain" : {
+        "title" : "OnChain",
+        "type" : "object",
+        "required" : [
+          "fiberCommits",
+          "latestLogs",
+          "registryCommits",
+          "assetCommits"
+        ],
+        "properties" : {
+          "fiberCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "latestLogs" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "registryCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "assetCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "OriginProvenance" : {
+        "title" : "OriginProvenance",
+        "type" : "object",
+        "required" : [
+          "originChainId",
+          "originAssetRef",
+          "attestationHash"
+        ],
+        "properties" : {
+          "originChainId" : {
+            "type" : "string"
+          },
+          "originAssetRef" : {
+            "type" : "string"
+          },
+          "fullPath" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "attestationHash" : {
+            "type" : "string"
+          }
+        }
+      },
+      "RegistryEntry" : {
+        "title" : "RegistryEntry",
+        "type" : "object",
+        "required" : [
+          "name",
+          "target",
+          "metadata"
+        ],
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "owner" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "target" : {
+            
+          },
+          "metadata" : {
+            "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "SchemaBinding" : {
+        "title" : "SchemaBinding",
+        "type" : "object",
+        "required" : [
+          "name",
+          "version",
+          "schemaHash",
+          "logicHash"
+        ],
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "string"
+          },
+          "schemaHash" : {
+            "type" : "string"
+          },
+          "logicHash" : {
+            "type" : "string"
+          }
+        }
+      },
       "ScriptFeeEstimate" : {
         "title" : "ScriptFeeEstimate",
         "type" : "object",
@@ -861,6 +1216,228 @@
           },
           "note" : {
             "type" : "string"
+          }
+        }
+      },
+      "ScriptFiberRecord" : {
+        "title" : "ScriptFiberRecord",
+        "type" : "object",
+        "required" : [
+          "fiberId",
+          "creationOrdinal",
+          "latestUpdateOrdinal",
+          "scriptProgram",
+          "accessControl",
+          "sequenceNumber",
+          "status"
+        ],
+        "properties" : {
+          "fiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "creationOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "latestUpdateOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "scriptProgram" : {
+            
+          },
+          "stateData" : {
+            
+          },
+          "stateDataHash" : {
+            "type" : "string"
+          },
+          "accessControl" : {
+            
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "owners" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "lastInvocation" : {
+            "$ref" : "#/components/schemas/ScriptInvocation"
+          },
+          "schemaBinding" : {
+            "$ref" : "#/components/schemas/SchemaBinding"
+          }
+        }
+      },
+      "ScriptInvocation" : {
+        "title" : "ScriptInvocation",
+        "type" : "object",
+        "required" : [
+          "fiberId",
+          "method",
+          "args",
+          "result",
+          "gasUsed",
+          "invokedAt",
+          "invokedBy"
+        ],
+        "properties" : {
+          "fiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "method" : {
+            "type" : "string"
+          },
+          "args" : {
+            
+          },
+          "result" : {
+            
+          },
+          "gasUsed" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "invokedAt" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "invokedBy" : {
+            "type" : "string"
+          }
+        }
+      },
+      "StateMachineFiberRecord" : {
+        "title" : "StateMachineFiberRecord",
+        "type" : "object",
+        "required" : [
+          "fiberId",
+          "creationOrdinal",
+          "previousUpdateOrdinal",
+          "latestUpdateOrdinal",
+          "definition",
+          "currentState",
+          "stateData",
+          "stateDataHash",
+          "sequenceNumber",
+          "status"
+        ],
+        "properties" : {
+          "fiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "creationOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "previousUpdateOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "latestUpdateOrdinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "definition" : {
+            
+          },
+          "currentState" : {
+            "type" : "string"
+          },
+          "stateData" : {
+            
+          },
+          "stateDataHash" : {
+            "type" : "string"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "owners" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "lastReceipt" : {
+            "$ref" : "#/components/schemas/EventReceipt"
+          },
+          "parentFiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "childFiberIds" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
+          },
+          "schemaBinding" : {
+            "$ref" : "#/components/schemas/SchemaBinding"
+          },
+          "authorizedSigners" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "StateProofResponse" : {
+        "title" : "StateProofResponse",
+        "type" : "object",
+        "required" : [
+          "key",
+          "ordinal",
+          "committedRoot",
+          "mptRoot",
+          "record",
+          "proof"
+        ],
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "committedRoot" : {
+            
+          },
+          "mptRoot" : {
+            
+          },
+          "record" : {
+            
+          },
+          "proof" : {
+            
+          },
+          "field" : {
+            "type" : "string"
+          },
+          "fieldValue" : {
+            
           }
         }
       },
@@ -946,6 +1523,34 @@
             "items" : {
               "$ref" : "#/components/schemas/Subscriber"
             }
+          }
+        }
+      },
+      "TokenBehavior" : {
+        "title" : "TokenBehavior",
+        "type" : "object",
+        "required" : [
+          "transferable",
+          "splittable",
+          "combinable",
+          "expirable",
+          "governable"
+        ],
+        "properties" : {
+          "transferable" : {
+            "type" : "boolean"
+          },
+          "splittable" : {
+            "type" : "boolean"
+          },
+          "combinable" : {
+            "type" : "boolean"
+          },
+          "expirable" : {
+            "type" : "boolean"
+          },
+          "governable" : {
+            "type" : "boolean"
           }
         }
       },

--- a/src/generated/openapi.ts
+++ b/src/generated/openapi.ts
@@ -382,6 +382,119 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** AssetCommit */
+        AssetCommit: {
+            /** Format: int32 */
+            behavior: number;
+            /** Format: int64 */
+            sequenceNumber: number;
+            recordHash: string;
+            origin?: string;
+        };
+        /** AssetRecord */
+        AssetRecord: {
+            /** Format: uuid */
+            assetId: string;
+            schemaBinding: components["schemas"]["SchemaBinding"];
+            behavior: components["schemas"]["TokenBehavior"];
+            holder: unknown;
+            /** Format: int64 */
+            amount: number;
+            /** Format: int64 */
+            sequenceNumber: number;
+            /** Format: int64 */
+            creationOrdinal: number;
+            /** Format: int64 */
+            latestUpdateOrdinal: number;
+            /** Format: int64 */
+            expiresAt?: number;
+            componentFiberIds?: string[];
+            componentsCommitment?: string;
+            /** Format: uuid */
+            parentCompositeId?: string;
+            provenance?: components["schemas"]["OriginProvenance"];
+        };
+        /** CalculatedState */
+        CalculatedState: {
+            stateMachines: components["schemas"]["Map_V"];
+            scripts: components["schemas"]["Map_V"];
+            registry: components["schemas"]["Map_V"];
+            reverseNames: components["schemas"]["Map_V"];
+            assets: components["schemas"]["Map_V"];
+            usedNonces: components["schemas"]["Map_V"];
+        };
+        /** Checkpoint_CalculatedState */
+        Checkpoint_CalculatedState: {
+            /** Format: int64 */
+            ordinal: number;
+            state: components["schemas"]["CalculatedState"];
+        };
+        /** EmittedEvent */
+        EmittedEvent: {
+            name: string;
+            data: unknown;
+            destination?: string;
+        };
+        /** EventReceipt */
+        EventReceipt: {
+            /** Format: uuid */
+            fiberId: string;
+            /** Format: int64 */
+            sequenceNumber: number;
+            eventName: string;
+            /** Format: int64 */
+            ordinal: number;
+            fromState: string;
+            toState: string;
+            success: boolean;
+            /** Format: int64 */
+            gasUsed: number;
+            /** Format: int32 */
+            triggersFired: number;
+            errorMessage?: string;
+            /** Format: uuid */
+            sourceFiberId?: string;
+            emittedEvents?: components["schemas"]["EmittedEvent"][];
+        };
+        /** FiberCommit */
+        FiberCommit: {
+            recordHash: string;
+            stateDataHash?: string;
+            /** Format: int64 */
+            sequenceNumber: number;
+        };
+        /** Map_V */
+        Map_V: {
+            [key: string]: components["schemas"]["FiberCommit"];
+        };
+        /** OnChain */
+        OnChain: {
+            fiberCommits: components["schemas"]["Map_V"];
+            latestLogs: components["schemas"]["Map_V"];
+            registryCommits: components["schemas"]["Map_V"];
+            assetCommits: components["schemas"]["Map_V"];
+        };
+        /** OriginProvenance */
+        OriginProvenance: {
+            originChainId: string;
+            originAssetRef: string;
+            fullPath?: string[];
+            attestationHash: string;
+        };
+        /** RegistryEntry */
+        RegistryEntry: {
+            name: string;
+            owner?: string[];
+            target: unknown;
+            metadata: components["schemas"]["Map_V"];
+        };
+        /** SchemaBinding */
+        SchemaBinding: {
+            name: string;
+            version: string;
+            schemaHash: string;
+            logicHash: string;
+        };
         /** ScriptFeeEstimate */
         ScriptFeeEstimate: {
             /** Format: uuid */
@@ -393,6 +506,75 @@ export interface components {
             /** Format: int32 */
             maxDepth: number;
             note: string;
+        };
+        /** ScriptFiberRecord */
+        ScriptFiberRecord: {
+            /** Format: uuid */
+            fiberId: string;
+            /** Format: int64 */
+            creationOrdinal: number;
+            /** Format: int64 */
+            latestUpdateOrdinal: number;
+            scriptProgram: unknown;
+            stateData?: unknown;
+            stateDataHash?: string;
+            accessControl: unknown;
+            /** Format: int64 */
+            sequenceNumber: number;
+            owners?: string[];
+            status: string;
+            lastInvocation?: components["schemas"]["ScriptInvocation"];
+            schemaBinding?: components["schemas"]["SchemaBinding"];
+        };
+        /** ScriptInvocation */
+        ScriptInvocation: {
+            /** Format: uuid */
+            fiberId: string;
+            method: string;
+            args: unknown;
+            result: unknown;
+            /** Format: int64 */
+            gasUsed: number;
+            /** Format: int64 */
+            invokedAt: number;
+            invokedBy: string;
+        };
+        /** StateMachineFiberRecord */
+        StateMachineFiberRecord: {
+            /** Format: uuid */
+            fiberId: string;
+            /** Format: int64 */
+            creationOrdinal: number;
+            /** Format: int64 */
+            previousUpdateOrdinal: number;
+            /** Format: int64 */
+            latestUpdateOrdinal: number;
+            definition: unknown;
+            currentState: string;
+            stateData: unknown;
+            stateDataHash: string;
+            /** Format: int64 */
+            sequenceNumber: number;
+            owners?: string[];
+            status: string;
+            lastReceipt?: components["schemas"]["EventReceipt"];
+            /** Format: uuid */
+            parentFiberId?: string;
+            childFiberIds?: string[];
+            schemaBinding?: components["schemas"]["SchemaBinding"];
+            authorizedSigners?: string[];
+        };
+        /** StateProofResponse */
+        StateProofResponse: {
+            key: string;
+            /** Format: int64 */
+            ordinal: number;
+            committedRoot: unknown;
+            mptRoot: unknown;
+            record: unknown;
+            proof: unknown;
+            field?: string;
+            fieldValue?: unknown;
         };
         /** SubscribeRequest */
         SubscribeRequest: {
@@ -422,6 +604,14 @@ export interface components {
         /** SubscriberList */
         SubscriberList: {
             subscribers?: components["schemas"]["Subscriber"][];
+        };
+        /** TokenBehavior */
+        TokenBehavior: {
+            transferable: boolean;
+            splittable: boolean;
+            combinable: boolean;
+            expirable: boolean;
+            governable: boolean;
         };
         /** TransitionFeeEstimate */
         TransitionFeeEstimate: {
@@ -521,13 +711,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OnChain */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["OnChain"];
                 };
             };
         };
@@ -541,13 +730,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Checkpoint[CalculatedState] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["Checkpoint_CalculatedState"];
                 };
             };
         };
@@ -564,13 +752,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description SortedMap[UUID, StateMachineFiberRecord] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["Map_V"];
                 };
             };
             /** @description Invalid value for: query parameter status */
@@ -595,13 +782,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Option[StateMachineFiberRecord] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StateMachineFiberRecord"];
                 };
             };
             /** @description Invalid value for: path parameter id */
@@ -626,13 +812,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description List[EventReceipt] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["EventReceipt"][];
                 };
             };
             /** @description Invalid value for: path parameter id */
@@ -723,13 +908,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description StateProofResponse */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StateProofResponse"];
                 };
             };
             /** @description Invalid value for: path parameter id, Invalid value for: query parameter field */
@@ -755,13 +939,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description SortedMap[UUID, ScriptFiberRecord] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["Map_V"];
                 };
             };
             /** @description Invalid value for: query parameter status */
@@ -786,13 +969,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Option[ScriptFiberRecord] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ScriptFiberRecord"];
                 };
             };
             /** @description Invalid value for: path parameter id */
@@ -817,13 +999,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description List[ScriptInvocation] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ScriptInvocation"][];
                 };
             };
             /** @description Invalid value for: path parameter id */
@@ -881,13 +1062,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description StateProofResponse */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StateProofResponse"];
                 };
             };
             /** @description Invalid value for: path parameter id, Invalid value for: query parameter field */
@@ -915,13 +1095,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description StateProofResponse */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StateProofResponse"];
                 };
             };
             /** @description Invalid value for: path parameter id, Invalid value for: query parameter field */
@@ -944,13 +1123,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description SortedMap[RegistryName, RegistryEntry] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["Map_V"];
                 };
             };
         };
@@ -966,13 +1144,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Option[RegistryName] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": string;
                 };
             };
             /** @description Invalid value for: path parameter id */
@@ -997,13 +1174,12 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Option[RegistryEntry] */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["RegistryEntry"];
                 };
             };
         };


### PR DESCRIPTION
## Why

Follow-up to #214 (merged). Sister to scasplte2/ottochain#174, which types the metagraph's domain response bodies in the OpenAPI contract. This re-vendors that contract and regenerates the SDK types, so the records/onchain/registry/state-proof responses are now typed instead of `unknown`.

## What
- Re-vendor `openapi/ottochain-openapi.json` (24 typed component schemas, was 7).
- Regenerate `src/generated/openapi.ts` → `ApiComponents['schemas']['StateMachineFiberRecord']` etc. are now typed records (uuid ids, integer ordinals, string hashes/status), with the JLVM program/state fields and sealed-trait unions as `unknown` (honest — see the chain-side PR for why).

## Verification
- `pnpm exec tsc --noEmit` → clean
- `pnpm gen:openapi` deterministic (the CI drift gate from #214 guards it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
