### PR TITLE
feat(schema): align SDK with chain FiberPolicy ADT (Unconstrained | Constrained)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,9 +142,16 @@ export type {
 export {
   toProtoDefinition,
   defineFiberApp,
+  // Fiber policy (the fiber constitution): mirrors the chain ADT
+  // `FiberPolicy = Unconstrained | Constrained(<dials>)`.
+  constrained,
+  unconstrained,
+  projectFiberPolicy,
   type ProtoStateMachineDefinition,
   type FiberAppDefinition,
   type FiberAppMetadata,
+  type FiberPolicy,
+  type FiberPolicyDials,
   type StateDefinition,
   type StdStateMetadata,
   type StateCategory,

--- a/src/ottochain/genesis-manifest.ts
+++ b/src/ottochain/genesis-manifest.ts
@@ -97,6 +97,11 @@ export interface StateMachineDefinition {
     dependencies: unknown[];
   }>;
   metadata: unknown | null;
+  /**
+   * Fiber constitution. PRESENT only for a `Constrained` policy (a bare object of the
+   * SET dials); ABSENT for `Unconstrained` (the chain emits no `policy` key for it).
+   */
+  policy?: Record<string, unknown>;
 }
 
 /**
@@ -237,6 +242,11 @@ function toWireDefinition(def: FiberAppDefinition): StateMachineDefinition {
     })),
     // Strip FiberAppMetadata — the chain's `metadata` is `Option[JsonLogicValue]`.
     metadata: null,
+    // Carry the fiber constitution through verbatim from the shared projector: PRESENT
+    // (a bare object of set dials) for `Constrained`, ABSENT for `Unconstrained`. The
+    // `policy` key is only set here when `toProtoDefinition` emitted one, so an
+    // unconstrained def keeps NO `policy` key (omit-on-unconstrained wire parity).
+    ...(proto.policy !== undefined ? { policy: proto.policy as Record<string, unknown> } : {}),
   };
 }
 

--- a/src/schema/fiber-app.ts
+++ b/src/schema/fiber-app.ts
@@ -147,6 +147,142 @@ export interface Transition<TState extends string = string, TEvent extends strin
 }
 
 // =============================================================================
+// Fiber Policy (the fiber "constitution")
+// =============================================================================
+
+/**
+ * `FiberPolicy` — the constitution a definition declares for the fibers it spawns.
+ *
+ * This MIRRORS the chain ADT `FiberPolicy = Unconstrained | Constrained(<dials>)`
+ * (chain branch `feat/fiber-policy-adt`). The representation here is chosen for
+ * BYTE-FOR-BYTE wire parity with the chain, because a `StateMachineDefinition` is
+ * signed verbatim by the SDK (`batchSign(dropNulls(...))`) and re-encoded + verified
+ * by the chain. The rule is:
+ *
+ *   - **`Unconstrained`** ⇒ there is **NO `policy` key** on the wire definition at all.
+ *     In the SDK this is the DEFAULT and is represented by simply OMITTING `policy`
+ *     (i.e. `policy === undefined`).
+ *   - **`Constrained(dials)`** ⇒ `policy` is a bare object of ONLY the dials that are
+ *     SET. Unset dials are absent (the chain `dropNulls`-strips them; so does the SDK
+ *     at sign time). A `Constrained` with no dials set is wire-indistinguishable from
+ *     `Unconstrained`, so `toProtoDefinition` collapses it back to "no policy key".
+ *
+ * All 14 dials are optional. Provide any subset.
+ */
+export interface FiberPolicyDials {
+  /** Whether the fiber may reproduce itself (spawn instances of its own definition). */
+  selfReproducing?: boolean;
+  /**
+   * Allow-list of reserved effect kinds this fiber may use, as a SET of effect-kind
+   * identifiers (e.g. the `_`-prefixed directive names: `_emit`, `_spawn`,
+   * `_transferAsset`, `_addDependency`, …). Order is not significant; duplicates are
+   * collapsed by the chain's `Set`.
+   */
+  allowedEffects?: readonly string[];
+  /** Policy governing who/what may own fibers this one spawns. */
+  spawnOwnerPolicy?: string;
+  /** Maximum spawn-generation depth (descendant chain length). */
+  maxGenerations?: number;
+  /** Maximum number of children a single fiber may spawn. */
+  maxSpawnFanout?: number;
+  /** SET of caller UUIDs permitted to drive transitions on this fiber. */
+  acceptedCallers?: readonly string[];
+  /** SET of state ids that are sealed (immutable / non-transitionable). */
+  sealedStates?: readonly string[];
+  /** Policy governing asset transfers out of the fiber. */
+  transferPolicy?: string;
+  /** Policy governing dynamic dependencies the fiber may bind. */
+  dependencyPolicy?: string;
+  /** Policy governing in-place upgrades / migrations. */
+  upgradePolicy?: string;
+  /** SemVer of this definition (constitution version). */
+  version?: string;
+  /** SemVer RANGE of definitions this one declares itself compatible with. */
+  compatibleWith?: string;
+  /** SET of interface identifiers this definition implements. */
+  interfaces?: readonly string[];
+  /** Authority permitted to migrate fibers governed by this policy. */
+  migrationAuthority?: string;
+}
+
+/**
+ * Wire form of a constrained policy — a bare object of the SET dials. This is what
+ * lands under `policy` on the projected `ProtoStateMachineDefinition`. Unset dials are
+ * stripped at projection time (and again by `dropNulls` at sign time), so this object
+ * matches the chain's `dropNulls`-stripped `Constrained` encoding exactly.
+ */
+export type FiberPolicy = FiberPolicyDials;
+
+/** The names of the 14 policy dials, in declaration order. Used by the projector. */
+const FIBER_POLICY_DIALS: readonly (keyof FiberPolicyDials)[] = [
+  'selfReproducing',
+  'allowedEffects',
+  'spawnOwnerPolicy',
+  'maxGenerations',
+  'maxSpawnFanout',
+  'acceptedCallers',
+  'sealedStates',
+  'transferPolicy',
+  'dependencyPolicy',
+  'upgradePolicy',
+  'version',
+  'compatibleWith',
+  'interfaces',
+  'migrationAuthority',
+];
+
+/**
+ * The canonical UNCONSTRAINED policy: omission. Provided as a named export for
+ * readability at call sites — `policy: unconstrained()` documents intent, and projects
+ * to NO `policy` key (identical to leaving `policy` off entirely).
+ */
+export function unconstrained(): undefined {
+  return undefined;
+}
+
+/**
+ * Build a CONSTRAINED `FiberPolicy` from any subset of the 14 dials.
+ *
+ * Pass only the dials you want to set. Dials left `undefined`/`null` are dropped so the
+ * result is a clean, minimal object that serializes identically to the chain's
+ * `dropNulls`-stripped `Constrained`. If NO dial is effectively set, this returns
+ * `undefined` (an empty constraint == `Unconstrained`), which projects to no `policy`
+ * key — preserving wire parity.
+ *
+ * @example
+ * ```ts
+ * const policy = constrained({
+ *   selfReproducing: false,
+ *   maxGenerations: 3,
+ *   allowedEffects: ['_emit', '_transferAsset'],
+ *   sealedStates: ['ARCHIVED'],
+ * });
+ * ```
+ */
+export function constrained(dials: FiberPolicyDials): FiberPolicy | undefined {
+  const out: Record<string, unknown> = {};
+  for (const k of FIBER_POLICY_DIALS) {
+    const v = dials[k];
+    if (v === undefined || v === null) continue;
+    out[k] = v;
+  }
+  return Object.keys(out).length === 0 ? undefined : (out as FiberPolicy);
+}
+
+/**
+ * Project an authoring `policy` value onto the wire form. Returns the minimal
+ * `Constrained` object, or `undefined` when the policy is (effectively) `Unconstrained`
+ * — i.e. omit the `policy` key. Centralizes the omit-on-unconstrained parity rule so
+ * every projection path (`toProtoDefinition`, the genesis manifest) stays consistent.
+ */
+export function projectFiberPolicy(policy: FiberPolicy | undefined): FiberPolicy | undefined {
+  if (policy === undefined || policy === null) return undefined;
+  // Re-run the dial filter so a hand-built object with explicit-undefined/empty dials
+  // collapses to Unconstrained exactly like `constrained()` does.
+  return constrained(policy);
+}
+
+// =============================================================================
 // Fiber App Definition
 // =============================================================================
 
@@ -176,7 +312,16 @@ export interface FiberAppDefinition<
   TEvent extends string = string
 > {
   metadata: FiberAppMetadata;
-  
+
+  /**
+   * Fiber constitution. Mirrors the chain ADT `FiberPolicy = Unconstrained |
+   * Constrained(<dials>)`. OMIT this field (the default) for `Unconstrained` — the
+   * projected wire definition then has NO `policy` key. Set it to a `constrained({...})`
+   * object to declare a subset of the 14 dials; unset dials are stripped so the wire
+   * form matches the chain's `dropNulls`-stripped `Constrained` byte-for-byte.
+   */
+  policy?: FiberPolicy;
+
   /** Schema for fiber creation inputs (user-provided) */
   createSchema?: {
     required?: readonly string[];
@@ -292,6 +437,13 @@ export interface ProtoStateMachineDefinition {
     dependencies: string[];
   }>;
   metadata?: Record<string, unknown>;
+  /**
+   * Fiber constitution. PRESENT only for a `Constrained` policy (a bare object of the
+   * SET dials); ABSENT for `Unconstrained`. This omit-on-unconstrained rule is the wire
+   * parity contract: the chain emits no `policy` key for `Unconstrained`, so neither may
+   * the SDK, or the signature breaks (HTTP 400). See {@link projectFiberPolicy}.
+   */
+  policy?: FiberPolicy;
 }
 
 /**
@@ -343,6 +495,16 @@ export function toProtoDefinition<T extends FiberAppDefinition>(
   // change the signed digest of an otherwise-identical machine), so it is deliberately NOT emitted
   // (the chain's `StateMachineDefinition.metadata` stays absent → `None`). A caller that genuinely
   // needs on-chain metadata sets `ProtoStateMachineDefinition.metadata` explicitly after conversion.
+
+  // Fiber constitution. OMIT the `policy` key entirely for `Unconstrained` (the chain
+  // emits nothing for it) and emit a bare object of only the SET dials for `Constrained`.
+  // `projectFiberPolicy` returns `undefined` for an (effectively) unconstrained policy, so
+  // we assign only when it is a real constraint — keeping the wire byte-for-byte identical
+  // to the chain's `dropNulls`-stripped encoding.
+  const policy = projectFiberPolicy(def.policy);
+  if (policy !== undefined) {
+    protoDef.policy = policy;
+  }
 
   return protoDef;
 }

--- a/tests/ottochain/signing-parity.test.ts
+++ b/tests/ottochain/signing-parity.test.ts
@@ -8,7 +8,12 @@
  * chain's `PublishVersionSigningCanonicalSuite` / `SdkCompatibilitySuite`.
  */
 import { describe, it, expect } from '@jest/globals';
-import { toProtoDefinition, defineFiberApp } from '../../src/schema/fiber-app.js';
+import {
+  toProtoDefinition,
+  defineFiberApp,
+  constrained,
+  unconstrained,
+} from '../../src/schema/fiber-app.js';
 import { dropNulls } from '../../src/ottochain/drop-nulls.js';
 import { identityUniversalDef } from '../../src/apps/identity/state-machines/identity-universal.js';
 import { govUniversalDef } from '../../src/apps/governance/state-machines/governance-universal.js';
@@ -52,8 +57,68 @@ describe('signing-canonical parity (SDK <-> chain wire StateMachineDefinition)',
       it('contains no `$timestamp` (the chain reserves $ordinal/$epochProgress, never $timestamp)', () => {
         expect(JSON.stringify(wire)).not.toContain('$timestamp');
       });
+
+      it('omits the `policy` key (std apps are Unconstrained == no policy key on the wire)', () => {
+        expect(wire).not.toHaveProperty('policy');
+        expect(JSON.stringify(wire)).not.toContain('"policy"');
+      });
     });
   }
+
+  describe('FiberPolicy projection (Unconstrained == omit, Constrained == bare set-dial object)', () => {
+    const base = {
+      metadata: { name: 'P', app: 'p', type: 'p', version: '1.0.0' },
+      states: { A: { id: 'A', isFinal: false }, B: { id: 'B', isFinal: true } },
+      initialState: 'A' as const,
+      transitions: [
+        { from: 'A', to: 'B', eventName: 'go', guard: { '==': [1, 1] }, effect: { var: 'state' } },
+      ],
+    };
+
+    it('omits `policy` entirely when the definition is unconstrained (no policy field)', () => {
+      const wire = toProtoDefinition(defineFiberApp({ ...base }));
+      expect(wire).not.toHaveProperty('policy');
+    });
+
+    it('omits `policy` when `policy: unconstrained()` is set explicitly', () => {
+      const wire = toProtoDefinition(defineFiberApp({ ...base, policy: unconstrained() }));
+      expect(wire).not.toHaveProperty('policy');
+    });
+
+    it('omits `policy` when a constrained() has zero effective dials (empty == Unconstrained)', () => {
+      const wire = toProtoDefinition(
+        defineFiberApp({ ...base, policy: constrained({ maxGenerations: undefined }) }),
+      );
+      expect(wire).not.toHaveProperty('policy');
+    });
+
+    it('emits `policy` as a bare object of ONLY the set dials when constrained', () => {
+      const wire = toProtoDefinition(
+        defineFiberApp({
+          ...base,
+          policy: constrained({
+            selfReproducing: false,
+            maxGenerations: 3,
+            allowedEffects: ['_emit', '_transferAsset'],
+            sealedStates: ['B'],
+          }),
+        }),
+      );
+      expect(wire.policy).toEqual({
+        selfReproducing: false,
+        maxGenerations: 3,
+        allowedEffects: ['_emit', '_transferAsset'],
+        sealedStates: ['B'],
+      });
+    });
+
+    it('strips unset dials so the wire matches the chain `dropNulls`-stripped Constrained', () => {
+      const wire = toProtoDefinition(
+        defineFiberApp({ ...base, policy: constrained({ maxGenerations: 2, transferPolicy: undefined }) }),
+      );
+      expect(Object.keys(wire.policy ?? {})).toEqual(['maxGenerations']);
+    });
+  });
 
   it('toProtoDefinition drops build-time-only DependencySpec objects + emits, keeping string deps', () => {
     const def = defineFiberApp({


### PR DESCRIPTION
## What

Aligns the SDK with the chain's new `FiberPolicy` design (chain branch `feat/fiber-policy-adt`) so SDK clients can declare a **fiber constitution** on a state-machine definition, serialized to match the chain **byte-for-byte**.

Mirrors the chain ADT:

```
FiberPolicy = Unconstrained | Constrained(<14 dials>)
```

## Where it lives (and why not protobuf)

A signed `StateMachineDefinition` does **not** flow through the generated protobuf — it is signed as raw JSON via `batchSign(dropNulls(toProtoDefinition(def)))`. The actual wire shape is `ProtoStateMachineDefinition` produced by `toProtoDefinition` in `src/schema/fiber-app.ts` (the TS-first source of truth). So the policy belongs on that typed authoring/projection layer, **not** in `src/generated/...`. No protobuf regen.

## Changes

- **`src/schema/fiber-app.ts`**
  - `FiberPolicyDials` — the 14 optional dials (`selfReproducing`, `allowedEffects`, `spawnOwnerPolicy`, `maxGenerations`, `maxSpawnFanout`, `acceptedCallers`, `sealedStates`, `transferPolicy`, `dependencyPolicy`, `upgradePolicy`, `version`, `compatibleWith`, `interfaces`, `migrationAuthority`).
  - `FiberPolicy` wire type + `constrained()` / `unconstrained()` / `projectFiberPolicy()` builders.
  - Optional `policy?: FiberPolicy` field on `FiberAppDefinition`.
  - `toProtoDefinition` now projects the policy.
- **`src/ottochain/genesis-manifest.ts`** — `toWireDefinition` carries the policy through with the same omit rule, so the genesis manifest never drifts.
- **`src/index.ts`** — exports the new surface.
- **`tests/ottochain/signing-parity.test.ts`** — locks the parity rules.

## The omit-on-wire parity rule (critical)

This is the contract that keeps the create signature valid:

- **`Unconstrained` ⇒ NO `policy` key at all.** The default; represented in the SDK by omitting `policy` (or `unconstrained()`, which is `undefined`).
- **`Constrained` ⇒ `policy: { <set dials> }`** — a bare object of only the SET dials. Unset dials are stripped (the chain `dropNulls`-strips them, and so does the SDK's `dropNulls` at sign time).
- An **empty/all-undefined** `Constrained` collapses back to `Unconstrained` (no `policy` key), since an empty constraint is wire-indistinguishable from unconstrained.

WHY it matters: the SDK signs over `dropNulls(message)`; the chain decodes, re-encodes, and verifies the signature over the re-encoded bytes. If the SDK emits a `policy` key the chain doesn't (or vice-versa), the bytes diverge and the create is rejected with an opaque `InvalidSignature` (empty-body HTTP 400). Omit == Unconstrained is what gives parity.

## Verification

- `npm run build` — succeeds (cjs + esm + types).
- `npm test` — **63 suites, 1373 passed, 6 skipped, 0 failures.**
- `npm run lint` — **0 errors** (95 pre-existing `no-explicit-any` warnings in test/generated files, none in touched files).
- New parity tests assert: std apps emit no `policy` key; unconstrained/`unconstrained()`/empty-constrained all omit `policy`; constrained emits only set dials in canonical order.

## Notes for review

- `allowedEffects` / `acceptedCallers` / `sealedStates` / `interfaces` are typed as `readonly string[]` (SETs of opaque identifiers) — the task spec describes them as sets without enumerating members, so they are kept open rather than over-constrained to a fixed union. Order is not significant (the chain collapses to a `Set`); the projector preserves author order.
- The four "policy" sub-dials (`spawnOwnerPolicy`, `transferPolicy`, `dependencyPolicy`, `upgradePolicy`) and `migrationAuthority` are typed as `string` placeholders — their inner shapes weren't specified in the handoff. If the chain expects nested objects/enums here, that's the one spot worth a second look; the omit-on-unconstrained wire contract is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)