### PR TITLE
feat(schema): add Immutable fiber policy variant + canonical collapse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,15 +143,18 @@ export {
   toProtoDefinition,
   defineFiberApp,
   // Fiber policy (the fiber constitution): mirrors the chain ADT
-  // `FiberPolicy = Unconstrained | Constrained(<dials>)`.
+  // `FiberPolicy = Unconstrained | Immutable | Constrained(<dials>)`.
   constrained,
   unconstrained,
+  immutable,
+  IMMUTABLE_POLICY,
   projectFiberPolicy,
   type ProtoStateMachineDefinition,
   type FiberAppDefinition,
   type FiberAppMetadata,
   type FiberPolicy,
   type FiberPolicyDials,
+  type ImmutablePolicy,
   type StateDefinition,
   type StdStateMetadata,
   type StateCategory,

--- a/src/ottochain/genesis-manifest.ts
+++ b/src/ottochain/genesis-manifest.ts
@@ -98,10 +98,11 @@ export interface StateMachineDefinition {
   }>;
   metadata: unknown | null;
   /**
-   * Fiber constitution. PRESENT only for a `Constrained` policy (a bare object of the
-   * SET dials); ABSENT for `Unconstrained` (the chain emits no `policy` key for it).
+   * Fiber constitution. PRESENT for `Constrained` (a bare object of the SET dials) and for
+   * `Immutable` (the bare JSON string `"Immutable"`); ABSENT for `Unconstrained` (the chain
+   * emits no `policy` key for it).
    */
-  policy?: Record<string, unknown>;
+  policy?: Record<string, unknown> | string;
 }
 
 /**
@@ -242,11 +243,14 @@ function toWireDefinition(def: FiberAppDefinition): StateMachineDefinition {
     })),
     // Strip FiberAppMetadata — the chain's `metadata` is `Option[JsonLogicValue]`.
     metadata: null,
-    // Carry the fiber constitution through verbatim from the shared projector: PRESENT
-    // (a bare object of set dials) for `Constrained`, ABSENT for `Unconstrained`. The
-    // `policy` key is only set here when `toProtoDefinition` emitted one, so an
-    // unconstrained def keeps NO `policy` key (omit-on-unconstrained wire parity).
-    ...(proto.policy !== undefined ? { policy: proto.policy as Record<string, unknown> } : {}),
+    // Carry the fiber constitution through verbatim from the shared projector: PRESENT for
+    // `Constrained` (a bare object of set dials) and `Immutable` (the bare string
+    // `"Immutable"`), ABSENT for `Unconstrained`. The `policy` key is only set here when
+    // `toProtoDefinition` emitted one, so an unconstrained def keeps NO `policy` key
+    // (omit-on-unconstrained wire parity).
+    ...(proto.policy !== undefined
+      ? { policy: proto.policy as Record<string, unknown> | string }
+      : {}),
   };
 }
 

--- a/src/schema/fiber-app.ts
+++ b/src/schema/fiber-app.ts
@@ -153,7 +153,7 @@ export interface Transition<TState extends string = string, TEvent extends strin
 /**
  * `FiberPolicy` — the constitution a definition declares for the fibers it spawns.
  *
- * This MIRRORS the chain ADT `FiberPolicy = Unconstrained | Constrained(<dials>)`
+ * This MIRRORS the chain ADT `FiberPolicy = Unconstrained | Immutable | Constrained(<dials>)`
  * (chain branch `feat/fiber-policy-adt`). The representation here is chosen for
  * BYTE-FOR-BYTE wire parity with the chain, because a `StateMachineDefinition` is
  * signed verbatim by the SDK (`batchSign(dropNulls(...))`) and re-encoded + verified
@@ -162,6 +162,11 @@ export interface Transition<TState extends string = string, TEvent extends strin
  *   - **`Unconstrained`** ⇒ there is **NO `policy` key** on the wire definition at all.
  *     In the SDK this is the DEFAULT and is represented by simply OMITTING `policy`
  *     (i.e. `policy === undefined`).
+ *   - **`Immutable`** ⇒ the definition is permanently locked; `policy` is the bare JSON
+ *     STRING `"Immutable"` (EXACT casing, capital-I) — NOT an object. Semantically this is
+ *     `upgradePolicy = IMMUTABLE` with no other dial set, and the chain collapses that exact
+ *     `Constrained` into the `Immutable` variant. See {@link immutable} and the canonical
+ *     collapse in {@link projectFiberPolicy}.
  *   - **`Constrained(dials)`** ⇒ `policy` is a bare object of ONLY the dials that are
  *     SET. Unset dials are absent (the chain `dropNulls`-strips them; so does the SDK
  *     at sign time). A `Constrained` with no dials set is wire-indistinguishable from
@@ -206,12 +211,25 @@ export interface FiberPolicyDials {
 }
 
 /**
- * Wire form of a constrained policy — a bare object of the SET dials. This is what
- * lands under `policy` on the projected `ProtoStateMachineDefinition`. Unset dials are
- * stripped at projection time (and again by `dropNulls` at sign time), so this object
- * matches the chain's `dropNulls`-stripped `Constrained` encoding exactly.
+ * The wire (and authoring) tag for the `Immutable` policy variant: the bare JSON string
+ * `"Immutable"`. EXACT casing, capital-I — this is the POLICY-LEVEL variant name and is
+ * distinct from the `upgradePolicy` dial VALUE `"IMMUTABLE"` (all-caps). The chain emits
+ * exactly this string for `Immutable`, so the SDK must too, byte-for-byte.
  */
-export type FiberPolicy = FiberPolicyDials;
+export const IMMUTABLE_POLICY = 'Immutable' as const;
+export type ImmutablePolicy = typeof IMMUTABLE_POLICY;
+
+/**
+ * Wire form of a `FiberPolicy`. Mirrors the chain ADT's non-`Unconstrained` arms:
+ *
+ *   - a bare object of the SET dials — the `Constrained` arm. Unset dials are stripped at
+ *     projection time (and again by `dropNulls` at sign time), so this object matches the
+ *     chain's `dropNulls`-stripped `Constrained` encoding exactly; OR
+ *   - the bare JSON string `"Immutable"` — the {@link ImmutablePolicy} arm.
+ *
+ * (`Unconstrained` has no wire representation: it is the absence of the `policy` key.)
+ */
+export type FiberPolicy = FiberPolicyDials | ImmutablePolicy;
 
 /** The names of the 14 policy dials, in declaration order. Used by the projector. */
 const FIBER_POLICY_DIALS: readonly (keyof FiberPolicyDials)[] = [
@@ -241,6 +259,22 @@ export function unconstrained(): undefined {
 }
 
 /**
+ * The canonical IMMUTABLE policy: the definition is permanently locked. Projects to the
+ * bare JSON string `"Immutable"` ({@link IMMUTABLE_POLICY}), the chain's `Immutable`
+ * variant tag. Semantically equivalent to `constrained({ upgradePolicy: 'IMMUTABLE' })`
+ * with no other dial set — which `constrained()`/`projectFiberPolicy()` collapse to the
+ * same string for wire parity (see {@link constrained}).
+ *
+ * @example
+ * ```ts
+ * const def = defineFiberApp({ ...spec, policy: immutable() });
+ * ```
+ */
+export function immutable(): ImmutablePolicy {
+  return IMMUTABLE_POLICY;
+}
+
+/**
  * Build a CONSTRAINED `FiberPolicy` from any subset of the 14 dials.
  *
  * Pass only the dials you want to set. Dials left `undefined`/`null` are dropped so the
@@ -248,6 +282,13 @@ export function unconstrained(): undefined {
  * `dropNulls`-stripped `Constrained`. If NO dial is effectively set, this returns
  * `undefined` (an empty constraint == `Unconstrained`), which projects to no `policy`
  * key — preserving wire parity.
+ *
+ * CANONICAL COLLAPSE: `constrained({ upgradePolicy: 'IMMUTABLE' })` with NO other dial set
+ * collapses to the bare string `"Immutable"` ({@link IMMUTABLE_POLICY}), because the chain
+ * collapses that exact `Constrained` into the `Immutable` variant. Signing the dials object
+ * `{ "upgradePolicy": "IMMUTABLE" }` instead would diverge the canonical (the chain re-encodes
+ * it as `"Immutable"`) and break the create signature. Adding ANY other dial keeps it a dials
+ * object.
  *
  * @example
  * ```ts
@@ -266,19 +307,31 @@ export function constrained(dials: FiberPolicyDials): FiberPolicy | undefined {
     if (v === undefined || v === null) continue;
     out[k] = v;
   }
-  return Object.keys(out).length === 0 ? undefined : (out as FiberPolicy);
+  const keys = Object.keys(out);
+  if (keys.length === 0) return undefined;
+  // Canonical collapse: a lone `upgradePolicy: 'IMMUTABLE'` IS the `Immutable` variant.
+  if (keys.length === 1 && out.upgradePolicy === 'IMMUTABLE') return IMMUTABLE_POLICY;
+  return out as FiberPolicy;
 }
 
 /**
- * Project an authoring `policy` value onto the wire form. Returns the minimal
- * `Constrained` object, or `undefined` when the policy is (effectively) `Unconstrained`
- * — i.e. omit the `policy` key. Centralizes the omit-on-unconstrained parity rule so
- * every projection path (`toProtoDefinition`, the genesis manifest) stays consistent.
+ * Project an authoring `policy` value onto the wire form. Returns one of:
+ *   - `undefined` when the policy is (effectively) `Unconstrained` — i.e. omit the `policy`
+ *     key entirely;
+ *   - the bare string `"Immutable"` ({@link IMMUTABLE_POLICY}) for the `Immutable` variant
+ *     (also the collapse of a lone `upgradePolicy: 'IMMUTABLE'`); or
+ *   - the minimal `Constrained` dials object otherwise.
+ *
+ * Centralizes the omit-on-unconstrained AND the Immutable-collapse parity rules so every
+ * projection path (`toProtoDefinition`, the genesis manifest) stays consistent.
  */
 export function projectFiberPolicy(policy: FiberPolicy | undefined): FiberPolicy | undefined {
   if (policy === undefined || policy === null) return undefined;
+  // The Immutable variant is already its canonical bare-string wire form.
+  if (policy === IMMUTABLE_POLICY) return IMMUTABLE_POLICY;
   // Re-run the dial filter so a hand-built object with explicit-undefined/empty dials
-  // collapses to Unconstrained exactly like `constrained()` does.
+  // collapses to Unconstrained, and a lone `upgradePolicy: 'IMMUTABLE'` collapses to
+  // `"Immutable"`, exactly like `constrained()` does.
   return constrained(policy);
 }
 
@@ -314,11 +367,13 @@ export interface FiberAppDefinition<
   metadata: FiberAppMetadata;
 
   /**
-   * Fiber constitution. Mirrors the chain ADT `FiberPolicy = Unconstrained |
-   * Constrained(<dials>)`. OMIT this field (the default) for `Unconstrained` — the
-   * projected wire definition then has NO `policy` key. Set it to a `constrained({...})`
-   * object to declare a subset of the 14 dials; unset dials are stripped so the wire
-   * form matches the chain's `dropNulls`-stripped `Constrained` byte-for-byte.
+   * Fiber constitution. Mirrors the chain ADT `FiberPolicy = Unconstrained | Immutable |
+   * Constrained(<dials>)`. OMIT this field (the default) for `Unconstrained` — the projected
+   * wire definition then has NO `policy` key. Set it to `immutable()` to permanently lock the
+   * definition (projects to the bare string `"Immutable"`). Set it to a `constrained({...})`
+   * object to declare a subset of the 14 dials; unset dials are stripped so the wire form
+   * matches the chain's `dropNulls`-stripped `Constrained` byte-for-byte (and a lone
+   * `upgradePolicy: 'IMMUTABLE'` collapses to `"Immutable"`).
    */
   policy?: FiberPolicy;
 
@@ -438,10 +493,11 @@ export interface ProtoStateMachineDefinition {
   }>;
   metadata?: Record<string, unknown>;
   /**
-   * Fiber constitution. PRESENT only for a `Constrained` policy (a bare object of the
-   * SET dials); ABSENT for `Unconstrained`. This omit-on-unconstrained rule is the wire
-   * parity contract: the chain emits no `policy` key for `Unconstrained`, so neither may
-   * the SDK, or the signature breaks (HTTP 400). See {@link projectFiberPolicy}.
+   * Fiber constitution. PRESENT for `Constrained` (a bare object of the SET dials) and for
+   * `Immutable` (the bare string `"Immutable"`); ABSENT for `Unconstrained`. This
+   * omit-on-unconstrained rule is the wire parity contract: the chain emits no `policy` key
+   * for `Unconstrained`, so neither may the SDK, or the signature breaks (HTTP 400). See
+   * {@link projectFiberPolicy}.
    */
   policy?: FiberPolicy;
 }
@@ -497,10 +553,10 @@ export function toProtoDefinition<T extends FiberAppDefinition>(
   // needs on-chain metadata sets `ProtoStateMachineDefinition.metadata` explicitly after conversion.
 
   // Fiber constitution. OMIT the `policy` key entirely for `Unconstrained` (the chain
-  // emits nothing for it) and emit a bare object of only the SET dials for `Constrained`.
-  // `projectFiberPolicy` returns `undefined` for an (effectively) unconstrained policy, so
-  // we assign only when it is a real constraint — keeping the wire byte-for-byte identical
-  // to the chain's `dropNulls`-stripped encoding.
+  // emits nothing for it); emit the bare string `"Immutable"` for `Immutable`; emit a bare
+  // object of only the SET dials for `Constrained`. `projectFiberPolicy` returns `undefined`
+  // for an (effectively) unconstrained policy, so we assign only when it is a real policy —
+  // keeping the wire byte-for-byte identical to the chain's encoding.
   const policy = projectFiberPolicy(def.policy);
   if (policy !== undefined) {
     protoDef.policy = policy;

--- a/tests/ottochain/signing-parity.test.ts
+++ b/tests/ottochain/signing-parity.test.ts
@@ -13,6 +13,7 @@ import {
   defineFiberApp,
   constrained,
   unconstrained,
+  immutable,
 } from '../../src/schema/fiber-app.js';
 import { dropNulls } from '../../src/ottochain/drop-nulls.js';
 import { identityUniversalDef } from '../../src/apps/identity/state-machines/identity-universal.js';
@@ -117,6 +118,38 @@ describe('signing-canonical parity (SDK <-> chain wire StateMachineDefinition)',
         defineFiberApp({ ...base, policy: constrained({ maxGenerations: 2, transferPolicy: undefined }) }),
       );
       expect(Object.keys(wire.policy ?? {})).toEqual(['maxGenerations']);
+    });
+
+    it('emits `policy` as the bare string "Immutable" for an immutable() definition', () => {
+      const wire = toProtoDefinition(defineFiberApp({ ...base, policy: immutable() }));
+      expect(wire.policy).toBe('Immutable');
+      // EXACT casing: the capital-I variant tag, NOT the all-caps dial value.
+      expect(JSON.stringify(wire)).toContain('"policy":"Immutable"');
+      expect(JSON.stringify(wire)).not.toContain('IMMUTABLE');
+    });
+
+    it('COLLAPSE: constrained({ upgradePolicy: "IMMUTABLE" }) with only that dial → "Immutable"', () => {
+      // The chain collapses this exact lone-dial Constrained into the Immutable variant, so the
+      // SDK must sign the bare string `"Immutable"` (not `{ upgradePolicy: "IMMUTABLE" }`) or the
+      // create signature breaks against the chain's re-encoding.
+      const wire = toProtoDefinition(
+        defineFiberApp({ ...base, policy: constrained({ upgradePolicy: 'IMMUTABLE' }) }),
+      );
+      expect(wire.policy).toBe('Immutable');
+      // immutable() and the collapsed constrained() are wire-identical.
+      const wireDirect = toProtoDefinition(defineFiberApp({ ...base, policy: immutable() }));
+      expect(JSON.stringify(wire)).toBe(JSON.stringify(wireDirect));
+    });
+
+    it('does NOT collapse upgradePolicy=IMMUTABLE when ANOTHER dial is also set (stays a dials object)', () => {
+      const wire = toProtoDefinition(
+        defineFiberApp({
+          ...base,
+          policy: constrained({ upgradePolicy: 'IMMUTABLE', maxGenerations: 2 }),
+        }),
+      );
+      expect(typeof wire.policy).toBe('object');
+      expect(wire.policy).toEqual({ maxGenerations: 2, upgradePolicy: 'IMMUTABLE' });
     });
   });
 


### PR DESCRIPTION
Stacked on #224 (base `feat/fiber-policy-align`). Adds the third arm of the chain
FiberPolicy ADT: `FiberPolicy = Unconstrained | Immutable | Constrained(<dials>)`.

## What `Immutable` is
"The definition is permanently locked" — semantically `upgradePolicy = IMMUTABLE` with
**no other dial set**. Its wire form is the **bare JSON string** `"policy": "Immutable"`
(EXACT casing, capital-I). This is the *policy-level variant name* and is distinct from
the all-caps `"IMMUTABLE"` dial *value*. The chain emits exactly this string, so the SDK
must too, or the signed `StateMachineDefinition` diverges and the create is rejected
(`InvalidSignature` / HTTP 400).

The three wire forms the SDK now produces, matching the chain byte-for-byte:
- `Unconstrained` → no `policy` key (from #224).
- `Immutable` → `"policy": "Immutable"` (a JSON string) — **new**.
- `Constrained` → `"policy": { <set dials> }` (from #224).

## How the union was extended
- `FiberPolicy` is now `FiberPolicyDials | ImmutablePolicy`, where `ImmutablePolicy` is the
  `"Immutable"` string literal. Added the `IMMUTABLE_POLICY` const and `ImmutablePolicy`
  type, exported from the package root alongside the new `immutable()` builder.

## Projection + canonical collapse
- New `immutable()` builder (peer of `unconstrained()`/`constrained()`) returns the bare
  `"Immutable"` tag.
- `projectFiberPolicy` passes `"Immutable"` through as its own canonical wire form; both
  `toProtoDefinition` and the genesis manifest's `toWireDefinition` carry it verbatim.
- **CANONICAL COLLAPSE (load-bearing for signature parity):** `constrained()` now collapses
  a lone `upgradePolicy: 'IMMUTABLE'` (no other dial set) to the string `"Immutable"`, NOT
  `{ upgradePolicy: 'IMMUTABLE' }`. The chain collapses that exact `Constrained` into the
  `Immutable` variant, so the SDK must too — otherwise the chain re-encodes it as
  `"Immutable"` while the SDK signed the object, breaking the create signature. Adding ANY
  other dial keeps it a dials object.

## Tests
Added to `tests/ottochain/signing-parity.test.ts`:
- (a) `immutable()` definition → `"policy": "Immutable"` (and asserts no `"IMMUTABLE"`).
- (b) `constrained({ upgradePolicy: 'IMMUTABLE' })` with only that dial → wire-identical to
  `immutable()` (the collapse).
- (c) `upgradePolicy=IMMUTABLE` + another dial → stays a dials object.

`npm run build` + `npm test` (1376 passed, 6 skipped) green; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)