### PR TITLE
fix(schema): reconcile FiberPolicy dial encodings to chain wire forms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,15 +143,27 @@ export {
   toProtoDefinition,
   defineFiberApp,
   // Fiber policy (the fiber constitution): mirrors the chain ADT
-  // `FiberPolicy = Unconstrained | Constrained(<dials>)`.
+  // `FiberPolicy = Unconstrained | Immutable | Constrained(<dials>)`.
   constrained,
   unconstrained,
+  immutable,
+  IMMUTABLE_POLICY,
   projectFiberPolicy,
   type ProtoStateMachineDefinition,
   type FiberAppDefinition,
   type FiberAppMetadata,
   type FiberPolicy,
   type FiberPolicyDials,
+  type ImmutablePolicy,
+  // Precise dial-value types (EXACT chain wire encodings) for rich `constrained({...})` calls.
+  type EffectKind,
+  type SpawnOwnerPolicy,
+  type DependencyMode,
+  type TransferPolicy,
+  type DependencyPolicy,
+  type MigrationAuthority,
+  type UpgradePolicy,
+  type VersionRange,
   type StateDefinition,
   type StdStateMetadata,
   type StateCategory,

--- a/src/ottochain/genesis-manifest.ts
+++ b/src/ottochain/genesis-manifest.ts
@@ -98,10 +98,11 @@ export interface StateMachineDefinition {
   }>;
   metadata: unknown | null;
   /**
-   * Fiber constitution. PRESENT only for a `Constrained` policy (a bare object of the
-   * SET dials); ABSENT for `Unconstrained` (the chain emits no `policy` key for it).
+   * Fiber constitution. PRESENT for `Constrained` (a bare object of the SET dials) and for
+   * `Immutable` (the bare JSON string `"Immutable"`); ABSENT for `Unconstrained` (the chain
+   * emits no `policy` key for it).
    */
-  policy?: Record<string, unknown>;
+  policy?: Record<string, unknown> | string;
 }
 
 /**
@@ -242,11 +243,14 @@ function toWireDefinition(def: FiberAppDefinition): StateMachineDefinition {
     })),
     // Strip FiberAppMetadata — the chain's `metadata` is `Option[JsonLogicValue]`.
     metadata: null,
-    // Carry the fiber constitution through verbatim from the shared projector: PRESENT
-    // (a bare object of set dials) for `Constrained`, ABSENT for `Unconstrained`. The
-    // `policy` key is only set here when `toProtoDefinition` emitted one, so an
-    // unconstrained def keeps NO `policy` key (omit-on-unconstrained wire parity).
-    ...(proto.policy !== undefined ? { policy: proto.policy as Record<string, unknown> } : {}),
+    // Carry the fiber constitution through verbatim from the shared projector: PRESENT for
+    // `Constrained` (a bare object of set dials) and `Immutable` (the bare string
+    // `"Immutable"`), ABSENT for `Unconstrained`. The `policy` key is only set here when
+    // `toProtoDefinition` emitted one, so an unconstrained def keeps NO `policy` key
+    // (omit-on-unconstrained wire parity).
+    ...(proto.policy !== undefined
+      ? { policy: proto.policy as Record<string, unknown> | string }
+      : {}),
   };
 }
 

--- a/src/schema/fiber-app.ts
+++ b/src/schema/fiber-app.ts
@@ -150,10 +150,109 @@ export interface Transition<TState extends string = string, TEvent extends strin
 // Fiber Policy (the fiber "constitution")
 // =============================================================================
 
+// ─── Dial value types (EXACT chain wire encodings) ───────────────────────────
+// These mirror the chain's `FiberPolicy.scala` codecs byte-for-byte. The chain
+// re-encodes and verifies over `JCS(dropNulls(payload))`, so any divergence in
+// casing or shape silently breaks the create signature (opaque HTTP 400). Each
+// type is annotated with the exact Scala source it mirrors.
+
+/**
+ * `allowedEffects` element — the 5 `EffectKind` families, UPPERCASE on the wire
+ * (`enumeratum` `Uppercase` mixin). Chain: `EffectKind` in `FiberPolicy.scala`.
+ */
+export type EffectKind = 'TRIGGER' | 'SPAWN' | 'EMIT' | 'TRANSFER' | 'DEPENDENCY';
+
+/**
+ * `spawnOwnerPolicy` — UPPERCASE (`enumeratum` `Uppercase`). Chain: `SpawnOwnerPolicy`
+ * (`Explicit` / `SubsetOfParent` / `InheritParent` ⇒ `"EXPLICIT"` / `"SUBSETOFPARENT"`
+ * / `"INHERITPARENT"`).
+ */
+export type SpawnOwnerPolicy = 'EXPLICIT' | 'SUBSETOFPARENT' | 'INHERITPARENT';
+
+/**
+ * `dependencyPolicy.mode` — UPPERCASE (`enumeratum` `Uppercase`). Chain: `DependencyMode`
+ * (`Open` / `Allowlist` / `Frozen`). REQUIRED on the wire (Scala defaults it to `Open`,
+ * but the `customizableEncoder` always encodes the value).
+ */
+export type DependencyMode = 'OPEN' | 'ALLOWLIST' | 'FROZEN';
+
+/**
+ * `transferPolicy` — recipient allowlist for `_transferAsset`. Chain: `TransferPolicy`
+ * (`Option[Set[UUID]]` fibers, `Option[Set[Address]]` wallets). Each field is OPTIONAL;
+ * an absent field ⇒ that recipient class is unconstrained (and is `dropNulls`-stripped).
+ */
+export interface TransferPolicy {
+  /** Fiber UUIDs permitted to receive a transfer. */
+  allowedRecipientFibers?: readonly string[];
+  /** DAG wallet addresses permitted to receive a transfer. */
+  allowedRecipientWallets?: readonly string[];
+}
+
+/**
+ * `dependencyPolicy` — dynamic-dependency posture. Chain: `DependencyPolicy`
+ * (`mode: DependencyMode`, `allowed: Option[Set[UUID]]`). `mode` is REQUIRED; `allowed`
+ * is meaningful only when `mode === 'ALLOWLIST'` and is `dropNulls`-stripped otherwise.
+ */
+export interface DependencyPolicy {
+  /** Posture: `OPEN` (any target) / `ALLOWLIST` (only `allowed`) / `FROZEN` (no new). */
+  mode: DependencyMode;
+  /** Fiber UUIDs permitted as dependency targets (meaningful only under `ALLOWLIST`). */
+  allowed?: readonly string[];
+}
+
+/**
+ * `migrationAuthority` — who may authorize a `Governed` migration. Chain:
+ * `MigrationAuthority`, a DISJOINT-FIELD discriminated union (no tag key): the `Signers`
+ * arm carries `addresses`, the `Role` arm carries `registryFiberId` + `roleField`. The
+ * presence of disjoint fields is the discriminator (same as the chain decoder's `.or`).
+ */
+export type MigrationAuthority =
+  | {
+      /** VERIFIED signer DAG addresses permitted to authorize the migration (`Signers`). */
+      addresses: readonly string[];
+    }
+  | {
+      /** Registry fiber UUID whose role-map is consulted (`Role`). */
+      registryFiberId: string;
+      /** Field/key in that fiber's state holding the `{<address>: true}` role map (`Role`). */
+      roleField: string;
+    };
+
+/**
+ * `upgradePolicy` — the upgrade-path constitution. Chain: `UpgradePolicy`. The three
+ * bare variants encode as LOWERCASE tag STRINGS (`"immutable"` / `"appendOnly"` /
+ * `"arbitrary"`); the `Governed` arm encodes as the object `{ authority: <MigrationAuthority> }`.
+ *
+ * NOTE: this lowercase `"immutable"` is the upgradePolicy DIAL VALUE — distinct from the
+ * policy-level variant tag `"Immutable"` (capital-I), a different construct added in a
+ * later change.
+ */
+export type UpgradePolicy =
+  | 'immutable'
+  | 'appendOnly'
+  | 'arbitrary'
+  | {
+      /** Authority that may consent to a `Governed` migration. */
+      authority: MigrationAuthority;
+    };
+
+/**
+ * `compatibleWith` — the inclusive-min / exclusive-max SemVer bridge window a migration
+ * may target. Chain: `VersionRange` (`min: Option[SemVer]`, `max: Option[SemVer]`). Each
+ * bound is a SemVer STRING (`"1.2.3"`); an absent bound is unconstrained on that side and
+ * is `dropNulls`-stripped.
+ */
+export interface VersionRange {
+  /** Inclusive lower bound, e.g. `"1.0.0"` (absent ⇒ unconstrained below). */
+  min?: string;
+  /** Exclusive upper bound, e.g. `"2.0.0"` (absent ⇒ unconstrained above). */
+  max?: string;
+}
+
 /**
  * `FiberPolicy` — the constitution a definition declares for the fibers it spawns.
  *
- * This MIRRORS the chain ADT `FiberPolicy = Unconstrained | Constrained(<dials>)`
+ * This MIRRORS the chain ADT `FiberPolicy = Unconstrained | Immutable | Constrained(<dials>)`
  * (chain branch `feat/fiber-policy-adt`). The representation here is chosen for
  * BYTE-FOR-BYTE wire parity with the chain, because a `StateMachineDefinition` is
  * signed verbatim by the SDK (`batchSign(dropNulls(...))`) and re-encoded + verified
@@ -162,6 +261,11 @@ export interface Transition<TState extends string = string, TEvent extends strin
  *   - **`Unconstrained`** ⇒ there is **NO `policy` key** on the wire definition at all.
  *     In the SDK this is the DEFAULT and is represented by simply OMITTING `policy`
  *     (i.e. `policy === undefined`).
+ *   - **`Immutable`** ⇒ the definition is permanently locked; `policy` is the bare JSON
+ *     STRING `"Immutable"` (EXACT casing, capital-I) — NOT an object. Semantically this is
+ *     the upgradePolicy DIAL set to its LOWERCASE `"immutable"` value with no other dial
+ *     set, and the chain collapses that exact `Constrained` into the `Immutable` variant.
+ *     See {@link immutable} and the canonical collapse in {@link projectFiberPolicy}.
  *   - **`Constrained(dials)`** ⇒ `policy` is a bare object of ONLY the dials that are
  *     SET. Unset dials are absent (the chain `dropNulls`-strips them; so does the SDK
  *     at sign time). A `Constrained` with no dials set is wire-indistinguishable from
@@ -170,48 +274,84 @@ export interface Transition<TState extends string = string, TEvent extends strin
  * All 14 dials are optional. Provide any subset.
  */
 export interface FiberPolicyDials {
-  /** Whether the fiber may reproduce itself (spawn instances of its own definition). */
+  /** Whether the fiber may reproduce itself (spawn instances of its own definition). Wire: boolean. */
   selfReproducing?: boolean;
   /**
-   * Allow-list of reserved effect kinds this fiber may use, as a SET of effect-kind
-   * identifiers (e.g. the `_`-prefixed directive names: `_emit`, `_spawn`,
-   * `_transferAsset`, `_addDependency`, …). Order is not significant; duplicates are
-   * collapsed by the chain's `Set`.
+   * Allow-list of effect families this fiber's transitions may produce, as a SET of the 5
+   * UPPERCASE {@link EffectKind} tokens (`"TRIGGER" | "SPAWN" | "EMIT" | "TRANSFER" |
+   * "DEPENDENCY"`). Order is not significant; duplicates are collapsed by the chain's `Set`.
+   * Chain: `allowedEffects: Option[Set[EffectKind]]`.
    */
-  allowedEffects?: readonly string[];
-  /** Policy governing who/what may own fibers this one spawns. */
-  spawnOwnerPolicy?: string;
-  /** Maximum spawn-generation depth (descendant chain length). */
+  allowedEffects?: readonly EffectKind[];
+  /**
+   * Who/what may own fibers this one spawns — an UPPERCASE {@link SpawnOwnerPolicy} token
+   * (`"EXPLICIT" | "SUBSETOFPARENT" | "INHERITPARENT"`). Chain: `spawnOwnerPolicy: Option[SpawnOwnerPolicy]`.
+   */
+  spawnOwnerPolicy?: SpawnOwnerPolicy;
+  /** Maximum spawn-generation depth (descendant chain length). Wire: number. */
   maxGenerations?: number;
-  /** Maximum number of children a single fiber may spawn. */
+  /** Maximum number of children a single transition may spawn. Wire: number. */
   maxSpawnFanout?: number;
-  /** SET of caller UUIDs permitted to drive transitions on this fiber. */
+  /** SET of caller fiber UUIDs permitted to drive transitions on this fiber. Wire: string[]. */
   acceptedCallers?: readonly string[];
-  /** SET of state ids that are sealed (immutable / non-transitionable). */
+  /** SET of state ids that are sealed (no transition may fire from them). Wire: string[]. */
   sealedStates?: readonly string[];
-  /** Policy governing asset transfers out of the fiber. */
-  transferPolicy?: string;
-  /** Policy governing dynamic dependencies the fiber may bind. */
-  dependencyPolicy?: string;
-  /** Policy governing in-place upgrades / migrations. */
-  upgradePolicy?: string;
-  /** SemVer of this definition (constitution version). */
+  /**
+   * Recipient allowlist for `_transferAsset` — the {@link TransferPolicy} object
+   * `{ allowedRecipientFibers?: uuid[], allowedRecipientWallets?: DAG-address[] }`.
+   * Chain: `transferPolicy: Option[TransferPolicy]`.
+   */
+  transferPolicy?: TransferPolicy;
+  /**
+   * Dynamic-dependency policy — the {@link DependencyPolicy} object `{ mode, allowed? }`
+   * where `mode` is the REQUIRED UPPERCASE {@link DependencyMode}. Chain:
+   * `dependencyPolicy: Option[DependencyPolicy]`.
+   */
+  dependencyPolicy?: DependencyPolicy;
+  /**
+   * In-place upgrade/migration posture — an {@link UpgradePolicy}: a LOWERCASE bare tag
+   * (`"immutable" | "appendOnly" | "arbitrary"`) OR the `Governed` object
+   * `{ authority: <MigrationAuthority> }`. Chain: `upgradePolicy: Option[UpgradePolicy]`.
+   */
+  upgradePolicy?: UpgradePolicy;
+  /** Self-declared SemVer of this definition as a STRING `"major.minor.patch"` (e.g. `"1.2.3"`). Chain: `version: Option[SemVer]`. */
   version?: string;
-  /** SemVer RANGE of definitions this one declares itself compatible with. */
-  compatibleWith?: string;
-  /** SET of interface identifiers this definition implements. */
+  /**
+   * Migration bridge window — the {@link VersionRange} object `{ min?: semver, max?: semver }`
+   * naming the successor versions this definition declares it will migrate TO. Chain:
+   * `compatibleWith: Option[VersionRange]`.
+   */
+  compatibleWith?: VersionRange;
+  /** SET of (ERC-165-style) interface identifiers this definition advertises. Wire: string[]. */
   interfaces?: readonly string[];
-  /** Authority permitted to migrate fibers governed by this policy. */
-  migrationAuthority?: string;
+  /**
+   * Authority permitted to authorize a `Governed` migration — a {@link MigrationAuthority}:
+   * `{ addresses: DAG-address[] }` (Signers) OR `{ registryFiberId: uuid, roleField: string }`
+   * (Role), discriminated by disjoint fields. Chain: `migrationAuthority: Option[MigrationAuthority]`.
+   */
+  migrationAuthority?: MigrationAuthority;
 }
 
 /**
- * Wire form of a constrained policy — a bare object of the SET dials. This is what
- * lands under `policy` on the projected `ProtoStateMachineDefinition`. Unset dials are
- * stripped at projection time (and again by `dropNulls` at sign time), so this object
- * matches the chain's `dropNulls`-stripped `Constrained` encoding exactly.
+ * The wire (and authoring) tag for the `Immutable` policy VARIANT: the bare JSON string
+ * `"Immutable"`. EXACT casing, capital-I — this is the POLICY-LEVEL variant name and is
+ * DISTINCT from the `upgradePolicy` dial VALUE `"immutable"` (lowercase). The chain emits
+ * exactly this capital-I string for `Immutable`, so the SDK must too, byte-for-byte.
  */
-export type FiberPolicy = FiberPolicyDials;
+export const IMMUTABLE_POLICY = 'Immutable' as const;
+export type ImmutablePolicy = typeof IMMUTABLE_POLICY;
+
+/**
+ * Wire form of a `FiberPolicy`. Mirrors the chain ADT's non-`Unconstrained` arms:
+ *
+ *   - a bare object of the SET dials — the `Constrained` arm. Unset dials are stripped at
+ *     projection time (and again by `dropNulls` at sign time), so this object matches the
+ *     chain's `dropNulls`-stripped `Constrained` encoding exactly; OR
+ *   - the bare JSON string `"Immutable"` — the {@link ImmutablePolicy} arm.
+ *
+ * (`Unconstrained` has no wire representation: it is the absence of the `policy` key.)
+ */
+export type FiberPolicy = FiberPolicyDials | ImmutablePolicy;
 
 /** The names of the 14 policy dials, in declaration order. Used by the projector. */
 const FIBER_POLICY_DIALS: readonly (keyof FiberPolicyDials)[] = [
@@ -241,6 +381,22 @@ export function unconstrained(): undefined {
 }
 
 /**
+ * The canonical IMMUTABLE policy: the definition is permanently locked. Projects to the
+ * bare JSON string `"Immutable"` ({@link IMMUTABLE_POLICY}), the chain's `Immutable`
+ * variant tag. Semantically equivalent to `constrained({ upgradePolicy: 'immutable' })`
+ * with no other dial set — which `constrained()`/`projectFiberPolicy()` collapse to the
+ * same string for wire parity (see {@link constrained}).
+ *
+ * @example
+ * ```ts
+ * const def = defineFiberApp({ ...spec, policy: immutable() });
+ * ```
+ */
+export function immutable(): ImmutablePolicy {
+  return IMMUTABLE_POLICY;
+}
+
+/**
  * Build a CONSTRAINED `FiberPolicy` from any subset of the 14 dials.
  *
  * Pass only the dials you want to set. Dials left `undefined`/`null` are dropped so the
@@ -249,12 +405,21 @@ export function unconstrained(): undefined {
  * `undefined` (an empty constraint == `Unconstrained`), which projects to no `policy`
  * key — preserving wire parity.
  *
+ * CANONICAL COLLAPSE: `constrained({ upgradePolicy: 'immutable' })` with NO other dial set
+ * collapses to the bare string `"Immutable"` ({@link IMMUTABLE_POLICY}), because the chain
+ * collapses that exact `Constrained` into the `Immutable` variant. NOTE the casing: the
+ * collapse triggers on the chain's LOWERCASE upgradePolicy dial value `"immutable"`, and
+ * the result is the capital-I policy-variant tag `"Immutable"`. Signing the dials object
+ * `{ "upgradePolicy": "immutable" }` instead would diverge the canonical (the chain
+ * re-encodes it as `"Immutable"`) and break the create signature. Adding ANY other dial
+ * keeps it a dials object.
+ *
  * @example
  * ```ts
  * const policy = constrained({
  *   selfReproducing: false,
  *   maxGenerations: 3,
- *   allowedEffects: ['_emit', '_transferAsset'],
+ *   allowedEffects: ['EMIT', 'TRANSFER'],
  *   sealedStates: ['ARCHIVED'],
  * });
  * ```
@@ -266,19 +431,32 @@ export function constrained(dials: FiberPolicyDials): FiberPolicy | undefined {
     if (v === undefined || v === null) continue;
     out[k] = v;
   }
-  return Object.keys(out).length === 0 ? undefined : (out as FiberPolicy);
+  const keys = Object.keys(out);
+  if (keys.length === 0) return undefined;
+  // Canonical collapse: a lone LOWERCASE `upgradePolicy: 'immutable'` (the chain's dial
+  // value) IS the `Immutable` variant — emit the capital-I `"Immutable"` tag, not the dials.
+  if (keys.length === 1 && out.upgradePolicy === 'immutable') return IMMUTABLE_POLICY;
+  return out as FiberPolicy;
 }
 
 /**
- * Project an authoring `policy` value onto the wire form. Returns the minimal
- * `Constrained` object, or `undefined` when the policy is (effectively) `Unconstrained`
- * — i.e. omit the `policy` key. Centralizes the omit-on-unconstrained parity rule so
- * every projection path (`toProtoDefinition`, the genesis manifest) stays consistent.
+ * Project an authoring `policy` value onto the wire form. Returns one of:
+ *   - `undefined` when the policy is (effectively) `Unconstrained` — i.e. omit the `policy`
+ *     key entirely;
+ *   - the bare string `"Immutable"` ({@link IMMUTABLE_POLICY}) for the `Immutable` variant
+ *     (also the collapse of a lone LOWERCASE `upgradePolicy: 'immutable'`); or
+ *   - the minimal `Constrained` dials object otherwise.
+ *
+ * Centralizes the omit-on-unconstrained AND the Immutable-collapse parity rules so every
+ * projection path (`toProtoDefinition`, the genesis manifest) stays consistent.
  */
 export function projectFiberPolicy(policy: FiberPolicy | undefined): FiberPolicy | undefined {
   if (policy === undefined || policy === null) return undefined;
+  // The Immutable variant is already its canonical bare-string wire form.
+  if (policy === IMMUTABLE_POLICY) return IMMUTABLE_POLICY;
   // Re-run the dial filter so a hand-built object with explicit-undefined/empty dials
-  // collapses to Unconstrained exactly like `constrained()` does.
+  // collapses to Unconstrained, and a lone `upgradePolicy: 'immutable'` collapses to
+  // `"Immutable"`, exactly like `constrained()` does.
   return constrained(policy);
 }
 
@@ -314,11 +492,13 @@ export interface FiberAppDefinition<
   metadata: FiberAppMetadata;
 
   /**
-   * Fiber constitution. Mirrors the chain ADT `FiberPolicy = Unconstrained |
-   * Constrained(<dials>)`. OMIT this field (the default) for `Unconstrained` — the
-   * projected wire definition then has NO `policy` key. Set it to a `constrained({...})`
-   * object to declare a subset of the 14 dials; unset dials are stripped so the wire
-   * form matches the chain's `dropNulls`-stripped `Constrained` byte-for-byte.
+   * Fiber constitution. Mirrors the chain ADT `FiberPolicy = Unconstrained | Immutable |
+   * Constrained(<dials>)`. OMIT this field (the default) for `Unconstrained` — the projected
+   * wire definition then has NO `policy` key. Set it to `immutable()` to permanently lock the
+   * definition (projects to the bare string `"Immutable"`). Set it to a `constrained({...})`
+   * object to declare a subset of the 14 dials; unset dials are stripped so the wire form
+   * matches the chain's `dropNulls`-stripped `Constrained` byte-for-byte (and a lone
+   * `upgradePolicy: 'immutable'` collapses to `"Immutable"`).
    */
   policy?: FiberPolicy;
 
@@ -438,10 +618,11 @@ export interface ProtoStateMachineDefinition {
   }>;
   metadata?: Record<string, unknown>;
   /**
-   * Fiber constitution. PRESENT only for a `Constrained` policy (a bare object of the
-   * SET dials); ABSENT for `Unconstrained`. This omit-on-unconstrained rule is the wire
-   * parity contract: the chain emits no `policy` key for `Unconstrained`, so neither may
-   * the SDK, or the signature breaks (HTTP 400). See {@link projectFiberPolicy}.
+   * Fiber constitution. PRESENT for `Constrained` (a bare object of the SET dials) and for
+   * `Immutable` (the bare string `"Immutable"`); ABSENT for `Unconstrained`. This
+   * omit-on-unconstrained rule is the wire parity contract: the chain emits no `policy` key
+   * for `Unconstrained`, so neither may the SDK, or the signature breaks (HTTP 400). See
+   * {@link projectFiberPolicy}.
    */
   policy?: FiberPolicy;
 }
@@ -497,10 +678,10 @@ export function toProtoDefinition<T extends FiberAppDefinition>(
   // needs on-chain metadata sets `ProtoStateMachineDefinition.metadata` explicitly after conversion.
 
   // Fiber constitution. OMIT the `policy` key entirely for `Unconstrained` (the chain
-  // emits nothing for it) and emit a bare object of only the SET dials for `Constrained`.
-  // `projectFiberPolicy` returns `undefined` for an (effectively) unconstrained policy, so
-  // we assign only when it is a real constraint — keeping the wire byte-for-byte identical
-  // to the chain's `dropNulls`-stripped encoding.
+  // emits nothing for it); emit the bare string `"Immutable"` for `Immutable`; emit a bare
+  // object of only the SET dials for `Constrained`. `projectFiberPolicy` returns `undefined`
+  // for an (effectively) unconstrained policy, so we assign only when it is a real policy —
+  // keeping the wire byte-for-byte identical to the chain's encoding.
   const policy = projectFiberPolicy(def.policy);
   if (policy !== undefined) {
     protoDef.policy = policy;

--- a/tests/ottochain/signing-parity.test.ts
+++ b/tests/ottochain/signing-parity.test.ts
@@ -13,6 +13,7 @@ import {
   defineFiberApp,
   constrained,
   unconstrained,
+  immutable,
 } from '../../src/schema/fiber-app.js';
 import { dropNulls } from '../../src/ottochain/drop-nulls.js';
 import { identityUniversalDef } from '../../src/apps/identity/state-machines/identity-universal.js';
@@ -99,7 +100,7 @@ describe('signing-canonical parity (SDK <-> chain wire StateMachineDefinition)',
           policy: constrained({
             selfReproducing: false,
             maxGenerations: 3,
-            allowedEffects: ['_emit', '_transferAsset'],
+            allowedEffects: ['EMIT', 'TRANSFER'],
             sealedStates: ['B'],
           }),
         }),
@@ -107,7 +108,7 @@ describe('signing-canonical parity (SDK <-> chain wire StateMachineDefinition)',
       expect(wire.policy).toEqual({
         selfReproducing: false,
         maxGenerations: 3,
-        allowedEffects: ['_emit', '_transferAsset'],
+        allowedEffects: ['EMIT', 'TRANSFER'],
         sealedStates: ['B'],
       });
     });
@@ -117,6 +118,177 @@ describe('signing-canonical parity (SDK <-> chain wire StateMachineDefinition)',
         defineFiberApp({ ...base, policy: constrained({ maxGenerations: 2, transferPolicy: undefined }) }),
       );
       expect(Object.keys(wire.policy ?? {})).toEqual(['maxGenerations']);
+    });
+
+    it('emits `policy` as the bare string "Immutable" for an immutable() definition', () => {
+      const wire = toProtoDefinition(defineFiberApp({ ...base, policy: immutable() }));
+      expect(wire.policy).toBe('Immutable');
+      // EXACT casing: the capital-I policy-VARIANT tag, NOT the lowercase upgradePolicy dial value.
+      expect(JSON.stringify(wire)).toContain('"policy":"Immutable"');
+      // The lowercase dial value "immutable" must NOT appear anywhere on the wire.
+      expect(JSON.stringify(wire)).not.toContain('"immutable"');
+    });
+
+    it('COLLAPSE: constrained({ upgradePolicy: "immutable" }) with only that dial → "Immutable"', () => {
+      // The chain collapses this exact lone-dial Constrained (LOWERCASE `"immutable"` dial value)
+      // into the `Immutable` variant, so the SDK must sign the capital-I bare string `"Immutable"`
+      // (not `{ upgradePolicy: "immutable" }`) or the create signature breaks against the chain's
+      // re-encoding.
+      const wire = toProtoDefinition(
+        defineFiberApp({ ...base, policy: constrained({ upgradePolicy: 'immutable' }) }),
+      );
+      expect(wire.policy).toBe('Immutable');
+      // immutable() and the collapsed constrained() are wire-identical.
+      const wireDirect = toProtoDefinition(defineFiberApp({ ...base, policy: immutable() }));
+      expect(JSON.stringify(wire)).toBe(JSON.stringify(wireDirect));
+    });
+
+    it('does NOT collapse upgradePolicy="immutable" when ANOTHER dial is also set (stays a dials object)', () => {
+      const wire = toProtoDefinition(
+        defineFiberApp({
+          ...base,
+          policy: constrained({ upgradePolicy: 'immutable', maxGenerations: 2 }),
+        }),
+      );
+      expect(typeof wire.policy).toBe('object');
+      // Stays a dials object with the LOWERCASE dial value verbatim.
+      expect(wire.policy).toEqual({ maxGenerations: 2, upgradePolicy: 'immutable' });
+    });
+  });
+
+  // Each dial's EXACT chain wire encoding (FiberPolicy.scala). Casing / shape divergence
+  // silently breaks the create signature, so these are byte-for-byte assertions.
+  describe('dial wire encodings (EXACT chain FiberPolicy.scala parity)', () => {
+    const base = {
+      metadata: { name: 'P', app: 'p', type: 'p', version: '1.0.0' },
+      states: { A: { id: 'A', isFinal: false }, B: { id: 'B', isFinal: true } },
+      initialState: 'A' as const,
+      transitions: [
+        { from: 'A', to: 'B', eventName: 'go', guard: { '==': [1, 1] }, effect: { var: 'state' } },
+      ],
+    };
+    const policyOf = (dials: Parameters<typeof constrained>[0]) =>
+      toProtoDefinition(defineFiberApp({ ...base, policy: constrained(dials) })).policy;
+
+    it('allowedEffects: UPPERCASE EffectKind tokens, verbatim', () => {
+      expect(policyOf({ allowedEffects: ['TRIGGER', 'SPAWN', 'EMIT', 'TRANSFER', 'DEPENDENCY'] })).toEqual({
+        allowedEffects: ['TRIGGER', 'SPAWN', 'EMIT', 'TRANSFER', 'DEPENDENCY'],
+      });
+    });
+
+    it('spawnOwnerPolicy: UPPERCASE SpawnOwnerPolicy token', () => {
+      expect(policyOf({ spawnOwnerPolicy: 'SUBSETOFPARENT' })).toEqual({ spawnOwnerPolicy: 'SUBSETOFPARENT' });
+    });
+
+    it('transferPolicy: nested object of recipient allowlists', () => {
+      expect(
+        policyOf({
+          transferPolicy: {
+            allowedRecipientFibers: ['11111111-1111-1111-1111-111111111111'],
+            allowedRecipientWallets: ['DAG0000000000000000000000000000000000000000'],
+          },
+        }),
+      ).toEqual({
+        transferPolicy: {
+          allowedRecipientFibers: ['11111111-1111-1111-1111-111111111111'],
+          allowedRecipientWallets: ['DAG0000000000000000000000000000000000000000'],
+        },
+      });
+    });
+
+    it('dependencyPolicy: nested object with REQUIRED UPPERCASE mode + optional allowed', () => {
+      expect(
+        policyOf({
+          dependencyPolicy: { mode: 'ALLOWLIST', allowed: ['22222222-2222-2222-2222-222222222222'] },
+        }),
+      ).toEqual({
+        dependencyPolicy: { mode: 'ALLOWLIST', allowed: ['22222222-2222-2222-2222-222222222222'] },
+      });
+      // FROZEN with no allowed list — mode alone.
+      expect(policyOf({ dependencyPolicy: { mode: 'FROZEN' } })).toEqual({
+        dependencyPolicy: { mode: 'FROZEN' },
+      });
+    });
+
+    it('upgradePolicy: LOWERCASE bare tags', () => {
+      expect(policyOf({ upgradePolicy: 'appendOnly' })).toEqual({ upgradePolicy: 'appendOnly' });
+      expect(policyOf({ upgradePolicy: 'arbitrary' })).toEqual({ upgradePolicy: 'arbitrary' });
+      // lowercase "immutable" is the DIAL VALUE (distinct from the policy-level "Immutable" variant).
+      expect(policyOf({ upgradePolicy: 'immutable', maxGenerations: 1 })).toEqual({
+        upgradePolicy: 'immutable',
+        maxGenerations: 1,
+      });
+    });
+
+    it('upgradePolicy: Governed object { authority } with the Signers MigrationAuthority arm', () => {
+      expect(
+        policyOf({
+          upgradePolicy: { authority: { addresses: ['DAG0000000000000000000000000000000000000000'] } },
+        }),
+      ).toEqual({
+        upgradePolicy: { authority: { addresses: ['DAG0000000000000000000000000000000000000000'] } },
+      });
+    });
+
+    it('migrationAuthority: Signers arm = { addresses }, Role arm = { registryFiberId, roleField }', () => {
+      expect(policyOf({ migrationAuthority: { addresses: ['DAG0000000000000000000000000000000000000000'] } })).toEqual(
+        { migrationAuthority: { addresses: ['DAG0000000000000000000000000000000000000000'] } },
+      );
+      expect(
+        policyOf({
+          migrationAuthority: { registryFiberId: '33333333-3333-3333-3333-333333333333', roleField: 'admins' },
+        }),
+      ).toEqual({
+        migrationAuthority: { registryFiberId: '33333333-3333-3333-3333-333333333333', roleField: 'admins' },
+      });
+    });
+
+    it('version: a bare SemVer STRING (not an object)', () => {
+      const policy = policyOf({ version: '1.2.3' });
+      expect(policy).toEqual({ version: '1.2.3' });
+      expect(typeof (policy as { version: unknown }).version).toBe('string');
+    });
+
+    it('compatibleWith: nested { min, max } SemVer-string window', () => {
+      expect(policyOf({ compatibleWith: { min: '1.0.0', max: '2.0.0' } })).toEqual({
+        compatibleWith: { min: '1.0.0', max: '2.0.0' },
+      });
+    });
+
+    it('a rich multi-dial policy round-trips byte-identically through JSON', () => {
+      const rich = constrained({
+        selfReproducing: true,
+        allowedEffects: ['EMIT', 'TRANSFER'],
+        spawnOwnerPolicy: 'INHERITPARENT',
+        maxGenerations: 3,
+        maxSpawnFanout: 5,
+        acceptedCallers: ['44444444-4444-4444-4444-444444444444'],
+        sealedStates: ['B'],
+        transferPolicy: { allowedRecipientWallets: ['DAG0000000000000000000000000000000000000000'] },
+        dependencyPolicy: { mode: 'OPEN' },
+        upgradePolicy: 'appendOnly',
+        version: '2.1.0',
+        compatibleWith: { min: '2.0.0' },
+        interfaces: ['iVotable', 'iStakeable'],
+        migrationAuthority: { registryFiberId: '55555555-5555-5555-5555-555555555555', roleField: 'gov' },
+      });
+      const wire = toProtoDefinition(defineFiberApp({ ...base, policy: rich }));
+      expect(wire.policy).toEqual({
+        selfReproducing: true,
+        allowedEffects: ['EMIT', 'TRANSFER'],
+        spawnOwnerPolicy: 'INHERITPARENT',
+        maxGenerations: 3,
+        maxSpawnFanout: 5,
+        acceptedCallers: ['44444444-4444-4444-4444-444444444444'],
+        sealedStates: ['B'],
+        transferPolicy: { allowedRecipientWallets: ['DAG0000000000000000000000000000000000000000'] },
+        dependencyPolicy: { mode: 'OPEN' },
+        upgradePolicy: 'appendOnly',
+        version: '2.1.0',
+        compatibleWith: { min: '2.0.0' },
+        interfaces: ['iVotable', 'iStakeable'],
+        migrationAuthority: { registryFiberId: '55555555-5555-5555-5555-555555555555', roleField: 'gov' },
+      });
     });
   });
 


### PR DESCRIPTION
## What

Follow-up to #224 (align) and #225 (Immutable). Both merged with the
`Constrained` **dial values** stubbed as plain `string`/`string[]` and the
immutable-collapse checked against uppercase `'IMMUTABLE'` — neither matches
the chain's `FiberPolicy.scala` codec. So `main` currently carries a wire
**parity gap**: a client SETTING rich dials via `constrained({…})` would emit
bytes the chain re-encodes differently (HTTP 400 on create-signature).

This PR reconciles every dial to the chain's exact wire form.

## The corrections

| dial | chain wire form |
|------|-----------------|
| `allowedEffects` | UPPERCASE `EffectKind` — `'TRIGGER' \| 'SPAWN' \| 'EMIT' \| 'TRANSFER' \| 'DEPENDENCY'` |
| `spawnOwnerPolicy` | `'EXPLICIT' \| 'SUBSETOFPARENT' \| 'INHERITPARENT'` |
| `dependencyPolicy.mode` | `'OPEN' \| 'ALLOWLIST' \| 'FROZEN'` (required) |
| `upgradePolicy` | LOWERCASE bare tags `'immutable' \| 'appendOnly' \| 'arbitrary'`, or `{ authority }` (Governed) |
| `version` | bare SemVer **string** `"1.2.3"` |
| `compatibleWith` | `{ min?, max? }` (semver strings) |
| `transferPolicy` / `migrationAuthority` | nested objects |
| **collapse** | `constrained({ upgradePolicy: 'immutable' })` now matches the **lowercase** dial value → `IMMUTABLE_POLICY` |

The two "immutable" tokens stay distinct: the policy **variant** tag is
capital-I `"Immutable"`; the `upgradePolicy` **dial value** is lowercase
`"immutable"`.

## Scope

The `unconstrained` (omit-on-wire) and `immutable()` common paths were already
correct — this only affects rich `constrained`-with-dials clients.

## Verification

- `npm run build` clean, **1386 tests pass** (6 skipped), lint 0 errors
- Adds per-dial wire-parity tests: UPPERCASE enums, nested transfer/dependency
  objects, lowercase upgrade tags, Governed object, version-as-string,
  compatibleWith window, both `migrationAuthority` arms, a rich multi-dial
  round-trip, and the lowercase immutable-collapse cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq8Brxf3dqW5E2Np69UMNZ
