### PR TITLE
feat(templates): SDK fiber/asset template library (Phase A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
       "require": "./dist/cjs/zk/index.js",
       "types": "./dist/types/zk/index.d.ts"
     },
+    "./templates": {
+      "import": "./dist/esm/templates/index.js",
+      "require": "./dist/cjs/templates/index.js",
+      "types": "./dist/types/templates/index.d.ts"
+    },
     "./apps/identity": {
       "import": "./dist/esm/apps/identity/index.js",
       "require": "./dist/cjs/apps/identity/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,8 +195,19 @@ export {
   actorNotInArray,
 } from './schema/guards.js';
 
-// Reserved EFFECT-directive builders (dynamic dependencies, #24; whole-asset custody moves).
-export { addDependency, setDependencyActive, transferAsset } from './schema/effects.js';
+// Reserved EFFECT-directive builders (dynamic dependencies, #24; whole-asset custody moves;
+// cross-fiber triggers, spawn, emit + recipient-intent helpers; the reserved-key set for validators).
+export {
+  addDependency,
+  setDependencyActive,
+  transferAsset,
+  triggers,
+  spawn,
+  emit,
+  toFiber,
+  toWallet,
+  RESERVED_EFFECT_KEYS,
+} from './schema/effects.js';
 
 // ─── Privacy: shield any fiber app into a zk-jlvm-shielded private-state pool ──
 // See docs/design/zk-private-contract-state-rfc.md.

--- a/src/ottochain/transaction.ts
+++ b/src/ottochain/transaction.ts
@@ -12,6 +12,8 @@ import type {
   MintAsset,
   ApplyMorphism,
   AuthorizeCompose,
+  PublishMachineVersion,
+  UpgradeFiber,
 } from './types.js';
 import { signDataUpdate } from '../signing.js';
 
@@ -292,6 +294,20 @@ export function createAuthorizeComposePayload(
   params: AuthorizeCompose,
 ): { AuthorizeCompose: AuthorizeCompose } {
   return { AuthorizeCompose: params };
+}
+
+/** Wrap a {@link PublishMachineVersion} (create-or-append a STATE-MACHINE registry version). */
+export function createPublishMachineVersionPayload(
+  params: PublishMachineVersion,
+): { PublishMachineVersion: PublishMachineVersion } {
+  return { PublishMachineVersion: params };
+}
+
+/** Wrap an {@link UpgradeFiber} (re-pin a fiber to another registered version of the SAME package). */
+export function createUpgradeFiberPayload(
+  params: UpgradeFiber,
+): { UpgradeFiber: UpgradeFiber } {
+  return { UpgradeFiber: params };
 }
 
 /**

--- a/src/schema/effects.ts
+++ b/src/schema/effects.ts
@@ -15,6 +15,8 @@
  * ```
  */
 
+import type { ProtoStateMachineDefinition } from './fiber-app.js';
+
 /** A JSON-Logic value: a literal (string/number/bool) or a `{var}`/operator expression. */
 type JsonLogicValue = unknown;
 
@@ -70,3 +72,92 @@ export const setDependencyActive = (
 export const transferAsset = (
   transfers: { assetId: JsonLogicValue; recipient: JsonLogicValue }[],
 ): Record<string, unknown> => ({ _transferAsset: transfers });
+
+/**
+ * Recipient-intent labels for {@link transferAsset}. The `_transferAsset` `recipient` is a BARE
+ * string, NOT an `AssetHolder` object, and the chain's `EffectExtractor.parseRecipient` disambiguates
+ * it by SHAPE: a UUID-shaped string resolves to a `Fiber`, a DAG address resolves to a `Wallet` (UUID
+ * is tried first). These helpers are the IDENTITY function — they change NOTHING on the wire — they
+ * only document, at the call site, which arm the author intends:
+ *
+ * ```ts
+ * transferAsset([{ assetId, recipient: toFiber({ var: "event.retailerId" }) }]);  // → Fiber
+ * transferAsset([{ assetId, recipient: toWallet({ var: "event.agent" }) }]);       // → Wallet
+ * ```
+ */
+export const toFiber = (fiberId: JsonLogicValue): JsonLogicValue => fiberId;
+/** See {@link toFiber}: identity label marking a `transferAsset` recipient as a DAG-address Wallet. */
+export const toWallet = (address: JsonLogicValue): JsonLogicValue => address;
+
+/**
+ * `_triggers` (F4): fire one or more CROSS-FIBER events. Each entry is projected to
+ * `{ targetMachineId, eventName, payload }` — the exact shape the chain's `EffectExtractor` reads
+ * (`ReservedKeys.scala`, `EffectExtractor.scala`). `target` is the recipient fiber id (a literal UUID
+ * or an expression, e.g. `{ var: "event.retailerId" }`); `event` is the event NAME to enqueue on it;
+ * `payload` is the event body — omit it and the builder emits `{}` (never `null`).
+ *
+ * Authoring this as a builder makes a typo'd `_trigger` / `triggres` a TypeScript error rather than a
+ * silently-merged state field (the F4 foot-gun). Place the fragment INSIDE the effect's state-update
+ * map so it rides in the evaluated result the extractor reads.
+ *
+ * @example
+ * effect: { merge: [ { var: "state" }, {
+ *   status: "debt_current",
+ *   ...triggers([{ target: { var: "event.retailerId" }, event: "process_sale",
+ *     payload: { buyerId: { var: "machineId" }, quantity: { var: "event.quantity" } } }]),
+ * } ] }
+ */
+export const triggers = (
+  ts: { target: JsonLogicValue; event: string; payload?: Record<string, unknown> }[],
+): Record<string, unknown> => ({
+  _triggers: ts.map((t) => ({ targetMachineId: t.target, eventName: t.event, payload: t.payload ?? {} })),
+});
+
+/**
+ * `_spawn`: create one or more CHILD fibers, each from a literal machine `definition`. Each entry is
+ * `{ childId, definition, initialData, owners }` (`ReservedKeys.scala`, `EffectExtractor.scala`).
+ *
+ * The chain extracts `_spawn` from the effect EXPRESSION, not the evaluated result, so `definition`
+ * MUST be a literal {@link ProtoStateMachineDefinition} (e.g. a nested `machine().wireDefinition()` /
+ * `toProtoDefinition(child)` output) — NOT an expression the engine would evaluate at runtime.
+ *
+ * F8 gotcha — `owners` is load-bearing. A spawned child's transitions are gated by
+ * `owners ∪ authorizedSigners` (`riverdale-economy/README.md`), so EVERY party that will later drive
+ * the child (e.g. every bidder on a spawned auction) MUST be listed in `owners`, or their events are
+ * rejected. `owners` may be a literal id array or an expression (e.g. `{ var: "event.auctionOwners" }`);
+ * `childId` / `initialData` likewise accept literals or expressions.
+ */
+export const spawn = (
+  ds: {
+    childId: JsonLogicValue;
+    definition: ProtoStateMachineDefinition;
+    initialData: Record<string, unknown>;
+    owners: JsonLogicValue;
+  }[],
+): Record<string, unknown> => ({ _spawn: ds });
+
+/**
+ * `_emit`: emit one or more domain events to the fiber's outbox. Each entry is
+ * `{ name, data, destination? }` (`ReservedKeys.scala`, `EffectExtractor.scala`). `name` is the event
+ * name, `data` the body (a literal or an expression), and `destination` an OPTIONAL routing target —
+ * omit it when absent (callers never pass `null`, so it is simply absent on the wire).
+ */
+export const emit = (
+  es: { name: string; data: JsonLogicValue; destination?: string }[],
+): Record<string, unknown> => ({ _emit: es });
+
+/**
+ * The complete set of `_`-prefixed RESERVED effect keys the chain's `EffectExtractor` consumes and
+ * `StateMerger` strips from state (`ReservedKeys.scala:12-49`). Exported so a validator (Proposal 01)
+ * can reject an unknown `_`-prefixed key (a typo'd directive) instead of letting it silently leak into
+ * persisted state.
+ */
+export const RESERVED_EFFECT_KEYS = [
+  '_triggers',
+  '_spawn',
+  '_emit',
+  '_transferAsset',
+  '_scriptCall',
+  '_addDependency',
+  '_setDependencyActive',
+] as const;

--- a/src/templates/asset-policy.ts
+++ b/src/templates/asset-policy.ts
@@ -1,0 +1,267 @@
+/**
+ * Asset-policy preset builders (§1.1 of the SDK std-lib/templates handoff).
+ *
+ * Each builder is a PURE function that emits the exact {@link CreateAssetPolicy} wire body the chain
+ * re-derives — no `Date.now()`/`Math.random()`/`crypto.randomUUID()`; fixed inputs → fixed output. The
+ * on-chain policy `schemaHash` and `logicHash` are both `RegistryShape.AssetPolicy.computeDigest` over
+ * `behavior`/`supply`/`morphisms`/`stateShape` (no JSON-Logic body), so these presets are pure data.
+ *
+ * Hard invariants (CLAUDE.md rule #1 — the signed canonical is frozen):
+ *  - `behavior` is ALWAYS summed from {@link TOKEN_BEHAVIOR_BITS} (T=16, S=8, C=4, E=2, G=1), never a
+ *    magic literal int.
+ *  - `morphisms` is REQUIRED on the wire (presence required, emptiness meaningful) — emit `{}` when empty,
+ *    NEVER omit it.
+ *  - `supply` is REQUIRED — emit `{}` when there is no supply authority, never omit it.
+ *  - Absent optionals are OMITTED, never emitted as `null`/`undefined` (the chain signs over
+ *    `JCS(dropNulls(payload))`).
+ *
+ * @see src/ottochain/types.ts — CreateAssetPolicy, SupplyPolicy, MorphismSpec, MorphismKind, TOKEN_BEHAVIOR_BITS
+ */
+import {
+  TOKEN_BEHAVIOR_BITS,
+  type CreateAssetPolicy,
+  type JsonLogicExpression,
+  type MessageShape,
+  type MorphismKind,
+  type MorphismSpec,
+  type SupplyPolicy,
+} from '../ottochain/types.js';
+
+/** A behavior-bit NAME (a key of {@link TOKEN_BEHAVIOR_BITS}) — the only legal way to spell `behavior`. */
+export type BehaviorBitName = keyof typeof TOKEN_BEHAVIOR_BITS;
+
+/** The default mint/burn guard the riverdale presets use: an always-true predicate `{"==":[1,1]}`. */
+const alwaysTrue = (): JsonLogicExpression => ({ '==': [1, 1] });
+
+/** A `PUBLIC`-visibility morphism spec (the riverdale preset visibility). Fresh object per call. */
+const publicMorphism = (): MorphismSpec => ({ visibility: 'PUBLIC' });
+
+/** Sum behavior bits from their NAMES — never a magic literal int (CLAUDE.md #1). */
+export function sumBehavior(bits: readonly BehaviorBitName[]): number {
+  return bits.reduce((acc, name) => acc + TOKEN_BEHAVIOR_BITS[name], 0);
+}
+
+/**
+ * Derive the default `stateShape.typeName`: strip a trailing `.asset` label, PascalCase the remainder
+ * (splitting on `.`/`-`/`_`/space), then append `State`.
+ *   `rvd.asset` → `RvdState`, `goods.asset` → `GoodsState`, `capped.asset` → `CappedState`.
+ */
+export function defaultStateTypeName(name: string): string {
+  const ASSET_SUFFIX = '.asset';
+  const base = name.endsWith(ASSET_SUFFIX) ? name.slice(0, -ASSET_SUFFIX.length) : name;
+  const pascal = base
+    .split(/[.\-_\s]+/)
+    .filter(Boolean)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join('');
+  return `${pascal}State`;
+}
+
+/** Build a {@link SupplyPolicy}, OMITTING every absent field (no `undefined`/`null` keys). */
+function buildSupply(opts: {
+  maxSupply?: number;
+  mintPolicy?: JsonLogicExpression;
+  burnPolicy?: JsonLogicExpression;
+  decimals?: number;
+}): SupplyPolicy {
+  const supply: SupplyPolicy = {};
+  if (opts.maxSupply !== undefined) supply.maxSupply = opts.maxSupply;
+  if (opts.mintPolicy !== undefined) supply.mintPolicy = opts.mintPolicy;
+  if (opts.burnPolicy !== undefined) supply.burnPolicy = opts.burnPolicy;
+  if (opts.decimals !== undefined) supply.decimals = opts.decimals;
+  return supply;
+}
+
+/** Assemble the final {@link CreateAssetPolicy}, attaching `metadata` only when present. */
+function assemble(args: {
+  name: string;
+  version: string;
+  behavior: number;
+  supply: SupplyPolicy;
+  morphisms: Record<string, MorphismSpec>;
+  stateTypeName?: string;
+  metadata?: Record<string, string>;
+}): CreateAssetPolicy {
+  const stateShape: MessageShape = {
+    typeName: args.stateTypeName ?? defaultStateTypeName(args.name),
+    fields: [],
+  };
+  const policy: CreateAssetPolicy = {
+    name: args.name,
+    version: args.version,
+    behavior: args.behavior,
+    supply: args.supply,
+    morphisms: args.morphisms,
+    stateShape,
+  };
+  if (args.metadata !== undefined) policy.metadata = args.metadata;
+  return policy;
+}
+
+/**
+ * Fungible currency. Behavior `T|S|C = 28` (transferable + splittable + combinable). Standard morphism
+ * set TRANSFER + FRACTIONALIZE + STAKE (`stakeable`, default true) + BURN (when `burnable`), all PUBLIC.
+ *
+ * Reproduces `riverdale-economy/rvd-policy.json` exactly via
+ * `fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true })`.
+ */
+export function fungiblePolicy(p: {
+  /** Registry name; conventionally ends `.asset`. */
+  name: string;
+  /** SemVer string. */
+  version: string;
+  /** `supply.decimals` — fractional precision; omit for whole-unit. */
+  decimals?: number;
+  /** `supply.maxSupply` — omit ⇒ uncapped. */
+  maxSupply?: number;
+  /** true ⇒ `supply.mintPolicy = {"==":[1,1]}` (open mint). */
+  mintable?: boolean;
+  /** true ⇒ `supply.burnPolicy = {"==":[1,1]}` AND a BURN morphism. */
+  burnable?: boolean;
+  /** JSON-Logic predicate that OVERRIDES `mintable`'s default mint guard (and enables minting). */
+  mintGuard?: JsonLogicExpression;
+  /** default true ⇒ a STAKE morphism. */
+  stakeable?: boolean;
+  /** `stateShape.typeName`; default `${PascalCase(name-without-.asset)}State`. */
+  stateTypeName?: string;
+  /** Off-chain links grab-bag; omitted when absent. */
+  metadata?: Record<string, string>;
+}): CreateAssetPolicy {
+  const behavior = sumBehavior(['transferable', 'splittable', 'combinable']); // 28
+
+  const morphisms: Record<string, MorphismSpec> = {
+    TRANSFER: publicMorphism(),
+    FRACTIONALIZE: publicMorphism(),
+  };
+  if (p.stakeable !== false) morphisms.STAKE = publicMorphism();
+  if (p.burnable) morphisms.BURN = publicMorphism();
+
+  let mintPolicy: JsonLogicExpression | undefined;
+  if (p.mintGuard !== undefined) mintPolicy = p.mintGuard;
+  else if (p.mintable) mintPolicy = alwaysTrue();
+
+  const supply = buildSupply({
+    maxSupply: p.maxSupply,
+    mintPolicy,
+    burnPolicy: p.burnable ? alwaysTrue() : undefined,
+    decimals: p.decimals,
+  });
+
+  return assemble({
+    name: p.name,
+    version: p.version,
+    behavior,
+    supply,
+    morphisms,
+    stateTypeName: p.stateTypeName,
+    metadata: p.metadata,
+  });
+}
+
+/**
+ * Non-fungible token. Behavior `T = 16`, or `T|C = 20` with `combinable: true` (the riverdale
+ * `goods.asset`); `transferable: false` drops the T bit (a bound collectible). `morphisms` is `{}` by
+ * default (emitted explicitly, never omitted). Mintable by default ⇒ `supply.mintPolicy = {"==":[1,1]}`.
+ *
+ * Reproduces `riverdale-economy/goods-policy.json` exactly via
+ * `nftPolicy({ name: 'goods.asset', version: '1.0.0', combinable: true })`.
+ */
+export function nftPolicy(p: {
+  name: string;
+  version: string;
+  /** `T(16)` → `T|C(20)`. */
+  combinable?: boolean;
+  /** default true; false ⇒ drop the T bit (bound collectible: `0`, or `4` with `combinable`). */
+  transferable?: boolean;
+  /** default true ⇒ `supply.mintPolicy = {"==":[1,1]}`. */
+  mintable?: boolean;
+  /** JSON-Logic predicate that OVERRIDES the default mint guard. */
+  mintGuard?: JsonLogicExpression;
+  /** `supply.maxSupply` — omit ⇒ uncapped edition. */
+  maxSupply?: number;
+  /** `stateShape.typeName`; default `${PascalCase(name-without-.asset)}State`. */
+  stateTypeName?: string;
+  metadata?: Record<string, string>;
+}): CreateAssetPolicy {
+  const bits: BehaviorBitName[] = [];
+  if (p.transferable !== false) bits.push('transferable');
+  if (p.combinable) bits.push('combinable');
+  const behavior = sumBehavior(bits);
+
+  let mintPolicy: JsonLogicExpression | undefined;
+  if (p.mintGuard !== undefined) mintPolicy = p.mintGuard;
+  else if (p.mintable !== false) mintPolicy = alwaysTrue();
+
+  const supply = buildSupply({ maxSupply: p.maxSupply, mintPolicy });
+
+  return assemble({
+    name: p.name,
+    version: p.version,
+    behavior,
+    supply,
+    morphisms: {},
+    stateTypeName: p.stateTypeName,
+    metadata: p.metadata,
+  });
+}
+
+/**
+ * Soulbound token: non-transferable, governable only (`G = 1`; `+E = 3` when `expirable`). No TRANSFER
+ * morphism (`morphisms: {}`); minting is closed after issue (empty `supply`).
+ */
+export function soulboundPolicy(p: {
+  name: string;
+  version: string;
+  /** `+E(2)` ⇒ behavior `3`. */
+  expirable?: boolean;
+  /** `stateShape.typeName`; default `${PascalCase(name-without-.asset)}State`. */
+  stateTypeName?: string;
+  metadata?: Record<string, string>;
+}): CreateAssetPolicy {
+  const bits: BehaviorBitName[] = ['governable'];
+  if (p.expirable) bits.push('expirable');
+  const behavior = sumBehavior(bits);
+
+  return assemble({
+    name: p.name,
+    version: p.version,
+    behavior,
+    supply: buildSupply({}), // mint closed after issue
+    morphisms: {}, // non-transferable: no TRANSFER morphism
+    stateTypeName: p.stateTypeName,
+    metadata: p.metadata,
+  });
+}
+
+/**
+ * Escape hatch: declare `behavior` by NAME (summed from {@link TOKEN_BEHAVIOR_BITS}, never a magic int)
+ * and pass `supply` + `morphisms` through raw. Use when no preset fits.
+ *
+ * Reproduces `riverdale-economy/capped-policy.json` exactly via
+ * `customPolicy({ name: 'capped.asset', version: '1.0.0',
+ *                 behavior: ['transferable', 'splittable', 'combinable'],
+ *                 supply: { maxSupply: 100, mintPolicy: { '==': [1, 1] } }, morphisms: {} })`.
+ */
+export function customPolicy(p: {
+  name: string;
+  version: string;
+  /** Behavior-bit NAMES summed to the int (e.g. `['transferable','combinable']` ⇒ 20). Never a literal. */
+  behavior: readonly BehaviorBitName[];
+  /** Raw supply authority, passed through verbatim. */
+  supply: SupplyPolicy;
+  /** Raw morphism map, passed through verbatim (emit `{}` when empty, never omit). */
+  morphisms: Partial<Record<MorphismKind, MorphismSpec>>;
+  /** `stateShape.typeName`; default `${PascalCase(name-without-.asset)}State`. */
+  stateTypeName?: string;
+  metadata?: Record<string, string>;
+}): CreateAssetPolicy {
+  return assemble({
+    name: p.name,
+    version: p.version,
+    behavior: sumBehavior(p.behavior),
+    supply: p.supply,
+    morphisms: p.morphisms as Record<string, MorphismSpec>,
+    stateTypeName: p.stateTypeName,
+    metadata: p.metadata,
+  });
+}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,62 @@
+/**
+ * `@ottochain/sdk/templates` — the fiber & asset authoring template catalog.
+ *
+ * Typed builders that emit the EXACT canonical wire shapes app authors otherwise hand-roll as raw
+ * JSON-Logic (asset policies, versioned machines, effect directives, migrations, seeded state). Every
+ * builder is additive and pure — it returns the same wire shape the chain re-derives, so a template
+ * output signs to byte-identical `JCS(dropNulls(payload))` (CLAUDE.md rule #1). Hand-rolled JSON keeps
+ * working; these just make the recurring shapes typed, named, and mistake-resistant.
+ *
+ * Origin: the fiber-ergonomics program (ottochain `docs/proposals/fiber-ergonomics/`), Phase A — the
+ * `riverdale-economy` e2e is the migration proof (each preset reproduces its checked-in golden JSON).
+ *
+ * @example
+ * import {
+ *   fungiblePolicy, machine, transition, effect, guard,
+ *   transferAsset, triggers, spawn, seedState, seedFields,
+ * } from '@ottochain/sdk/templates';
+ */
+
+// ─── 1.1 Asset-policy presets ────────────────────────────────────────────────
+// fungiblePolicy / nftPolicy / soulboundPolicy / customPolicy (+ sumBehavior, defaultStateTypeName,
+// BehaviorBitName) — emit a `CreateAssetPolicy`; behavior is summed from TOKEN_BEHAVIOR_BITS, never a literal.
+export * from './asset-policy.js';
+
+// ─── 1.2 Versioned-machine skeleton + transition()/effect() ──────────────────
+// machine / transition / effect (+ TransitionSpec, MachineSpec, Machine, …). The skeleton owns ONE
+// canonical wire definition, so publish + create cannot drift (verified binding, F9).
+export * from './machine.js';
+
+// ─── 1.4 Migration helpers ───────────────────────────────────────────────────
+// seedFields / migration — hides the bare-state-root ({"var":""}) foot-gun.
+export * from './migration.js';
+
+// ─── 1.5 State-shape-with-defaults ───────────────────────────────────────────
+// seedState / declaredFields / StateShape — auto-seed accumulators so no field reads null (F5).
+export * from './state-shape.js';
+
+// ─── 1.3 Effect-directive builders ───────────────────────────────────────────
+// transferAsset / triggers / spawn / emit / toFiber / toWallet / addDependency / setDependencyActive /
+// RESERVED_EFFECT_KEYS — a typo'd directive is a TS error, not a silent state field (F4).
+export * from '../schema/effects.js';
+
+// ─── Authorization-guard builders (namespace) ────────────────────────────────
+// `guard.signerIsParty('state.borrower')` reads as intent at the call site.
+export * as guard from '../schema/guards.js';
+
+// ─── Existing machine/policy primitives re-surfaced for one-import authoring ──
+export {
+  defineFiberApp,
+  toProtoDefinition,
+  constrained,
+  unconstrained,
+  immutable,
+  projectFiberPolicy,
+} from '../schema/fiber-app.js';
+export type {
+  FiberAppDefinition,
+  Transition,
+  ProtoStateMachineDefinition,
+  FiberPolicy,
+  FiberPolicyDials,
+} from '../schema/fiber-app.js';

--- a/src/templates/machine.ts
+++ b/src/templates/machine.ts
@@ -1,0 +1,243 @@
+/**
+ * Versioned-machine skeleton + `transition()` / `effect()` composition (handoff §1.2).
+ *
+ * Two moves:
+ *   1. `transition()` / `effect()` build the wire `Transition` + its flat effect map from typed
+ *      fragments instead of a hand-rolled JSON blob.
+ *   2. `machine()` is a versioned-package SKELETON that OWNS exactly ONE canonical wire definition
+ *      (`toProtoDefinition(app)`, computed once) and hands the SAME object to BOTH `publishVersion()`
+ *      and `create()`. That is the verified-binding invariant (F9): because publish and create cannot
+ *      drift, the chain's `definition.computeDigest` equals the registered `logicHash` and the bind
+ *      admits the fiber. The skeleton REUSES `toProtoDefinition` (the one canonicalization path) — it
+ *      never re-derives the wire shape.
+ *
+ * Guardrail (CLAUDE.md #1): every builder here is a pure function emitting the exact wire shape the
+ * chain re-derives. Absent optionals (`metadata`/`participants`/`parentFiberId`/`migration`) are
+ * OMITTED, never `null`; required-no-default fields (`strict` on publish, `dependencies: []` per
+ * transition) are ALWAYS present.
+ */
+
+import {
+  toProtoDefinition,
+  type Transition,
+  type JsonLogicRule,
+  type DependencySpec,
+  type FiberAppDefinition,
+  type ProtoStateMachineDefinition,
+} from '../schema/fiber-app.js';
+import type {
+  MachineShape,
+  PublishMachineVersion,
+  CreateStateMachine,
+  UpgradeFiber,
+  SchemaRef,
+  SemVer,
+  JsonLogicValue,
+  JsonLogicExpression,
+} from '../ottochain/types.js';
+
+// =============================================================================
+// transition()
+// =============================================================================
+
+/** Authoring shape for {@link transition} — `on` is the event name (mapped to the wire `eventName`). */
+export interface TransitionSpec<TState extends string = string, TEvent extends string = string> {
+  from: TState;
+  to: TState;
+  /** Event that fires this transition. Mapped to the wire key `eventName`. */
+  on: TEvent;
+  /** JSON-Logic predicate; defaults to the always-true `{ "==": [1, 1] }` when omitted. */
+  guard?: JsonLogicRule;
+  /** The flat effect map (build it with {@link effect}). Passed through verbatim. */
+  effect?: JsonLogicRule;
+  /**
+   * Dependencies for this transition. Defaults to `[]` (ALWAYS present — the chain
+   * `Transition.dependencies: Set[UUID]` has no default; omitting it diverges the canonical).
+   * `toProtoDefinition` later drops any non-string {@link DependencySpec} authoring entries.
+   */
+  dependencies?: readonly (string | DependencySpec)[];
+}
+
+/**
+ * Build a wire {@link Transition} from a typed spec.
+ *
+ *   - `on` → `eventName` (the wire key);
+ *   - `guard` defaults to `{ "==": [1, 1] }`;
+ *   - `dependencies` defaults to `[]` and is ALWAYS present;
+ *   - `effect` is passed through (build it with {@link effect}).
+ *
+ * @example
+ * ```ts
+ * transition({
+ *   from: 'debt_current', to: 'debt_current', on: 'buy',
+ *   effect: effect(
+ *     { status: 'debt_current', purchaseCount: { '+': [{ var: 'state.purchaseCount' }, 1] } },
+ *     triggers([...]), transferAsset([...]),
+ *   ),
+ * });
+ * ```
+ */
+export function transition<TState extends string = string, TEvent extends string = string>(
+  t: TransitionSpec<TState, TEvent>,
+): Transition<TState, TEvent> {
+  return {
+    from: t.from,
+    to: t.to,
+    eventName: t.on,
+    guard: t.guard ?? { '==': [1, 1] },
+    effect: t.effect,
+    dependencies: t.dependencies ?? [],
+  };
+}
+
+// =============================================================================
+// effect()
+// =============================================================================
+
+/**
+ * Compose an effect into ONE FLAT map: the state-update fields PLUS any `_`-directive fragments,
+ * all in a single object (`Object.assign({}, stateUpdate, ...directives)`).
+ *
+ * Riverdale effects are flat maps that mix `_`-reserved directives (`_triggers`, `_transferAsset`,
+ * `_spawn`, …) with plain state-update fields — they are NOT `merge`-wrapped. Each directive fragment
+ * is a `Record` (e.g. the output of `transferAsset(...)` / `triggers(...)`), spread in here. Later
+ * fragments override earlier keys (`Object.assign` semantics).
+ *
+ * @example
+ * ```ts
+ * effect(
+ *   { status: 'debt_current', purchaseCount: { '+': [{ var: 'state.purchaseCount' }, 1] } },
+ *   { _triggers: [...] },
+ *   transferAsset([{ assetId: { var: 'event.payAssetId' }, recipient: { var: 'event.retailerId' } }]),
+ * );
+ * // => { status, purchaseCount, _triggers, _transferAsset }
+ * ```
+ */
+export function effect(
+  stateUpdate: Record<string, unknown>,
+  ...directives: Record<string, unknown>[]
+): Record<string, unknown> {
+  return Object.assign({}, stateUpdate, ...directives);
+}
+
+// =============================================================================
+// machine() — the versioned-package skeleton
+// =============================================================================
+
+/** The machine package spec: identity (`name`@`version`) + the one canonical `app` + its schema shape. */
+export interface MachineSpec<TState extends string = string, TEvent extends string = string> {
+  /** Full registry name `labels.tld` (e.g. `"consumer.package"`). */
+  name: string;
+  /** SemVer string (e.g. `"1.0.0"`). */
+  version: SemVer;
+  /** The typed fiber app; projected ONCE to the canonical wire definition via `toProtoDefinition`. */
+  app: FiberAppDefinition<TState, TEvent>;
+  /** The advisory proto projection the chain stores for discovery (carried onto `PublishMachineVersion.machineShape`). */
+  schemaShape: MachineShape;
+}
+
+/** Options for {@link Machine.publishVersion}. */
+export interface PublishVersionOptions {
+  /** Opt-in runtime conformance gate (#33). Defaults to `false` (REQUIRED on the wire — never omitted). */
+  strict?: boolean;
+  /** Optional off-chain links grab-bag; OMITTED when absent (never `null`). */
+  metadata?: Record<string, string>;
+  /**
+   * Base64 of the proto FileDescriptorSet. REQUIRED on the wire `PublishMachineVersion` (the chain
+   * base64-validates + hashes it, then drops the bytes), so it is ALWAYS present; defaults to the empty
+   * string `''` (valid empty base64) when the skeleton has no descriptor set bound. The verified binding
+   * hangs on `definition.computeDigest`, NOT on this field.
+   */
+  schemaB64?: string;
+}
+
+/** Options for {@link Machine.create}. */
+export interface CreateOptions {
+  fiberId: string;
+  /** Seeded fiber state (e.g. from `seedState(...)`); pre-seed accumulators so no field reads `null`. */
+  initialData: JsonLogicValue;
+  /** Optional DAG addresses authorized to sign transitions; OMITTED when absent (never `null`). */
+  participants?: string[];
+  /** Optional parent fiber UUID; OMITTED when absent (never `null`). */
+  parentFiberId?: string;
+}
+
+/** Options for {@link Machine.upgradeFrom}. */
+export interface UpgradeOptions {
+  fiberId: string;
+  targetSequenceNumber: number;
+  /** Optional JSON-Logic migration transform of the prior state; OMITTED when absent (never `null`). */
+  migration?: JsonLogicExpression;
+}
+
+/** The versioned-machine skeleton returned by {@link machine}. */
+export interface Machine {
+  /** The ONE canonical wire definition (`toProtoDefinition(app)`), shared by publish + create. */
+  wireDefinition(): ProtoStateMachineDefinition;
+  /** The `PublishMachineVersion` body — its `definition` is the SAME object as `wireDefinition()`. */
+  publishVersion(o?: PublishVersionOptions): PublishMachineVersion;
+  /** The `CreateStateMachine` body — references `name@version` via `schemaRef` + the SAME `definition`. */
+  create(o: CreateOptions): CreateStateMachine;
+  /** The `UpgradeFiber` body — re-pins to `name@version` with the SAME `newDefinition`. */
+  upgradeFrom(o: UpgradeOptions): UpgradeFiber;
+}
+
+/** A pinned-Exact `SchemaRef` for `name@version`. Wire: `{ name, version: { Exact: { version } } }`. */
+function exactRef(name: string, version: SemVer): SchemaRef {
+  return { name, version: { Exact: { version } } };
+}
+
+/**
+ * Build a versioned-machine skeleton that binds publish + create to ONE canonical definition.
+ *
+ * The definition is projected ONCE here (`toProtoDefinition(spec.app)`) and the SAME reference is handed
+ * to `wireDefinition()`, `publishVersion().definition`, `create().definition`, and
+ * `upgradeFrom().newDefinition` — so they cannot drift and the chain's verified binding admits the fiber
+ * (F9). REUSES `toProtoDefinition` (the single canonicalization path); never re-derives the wire shape.
+ */
+export function machine<TState extends string = string, TEvent extends string = string>(
+  spec: MachineSpec<TState, TEvent>,
+): Machine {
+  // Project the canonical wire definition ONCE; every consumer reuses this exact reference.
+  const wireDef: ProtoStateMachineDefinition = toProtoDefinition(spec.app);
+
+  return {
+    wireDefinition(): ProtoStateMachineDefinition {
+      return wireDef;
+    },
+
+    publishVersion(o?: PublishVersionOptions): PublishMachineVersion {
+      return {
+        name: spec.name,
+        version: spec.version,
+        // REQUIRED-no-default on the wire; '' is valid empty base64 when no descriptor set is bound.
+        schemaB64: o?.schemaB64 ?? '',
+        machineShape: spec.schemaShape,
+        definition: wireDef, // SAME reference as wireDefinition()/create()
+        strict: o?.strict ?? false, // REQUIRED — never omitted
+        ...(o?.metadata ? { metadata: o.metadata } : {}), // OMIT when absent
+      };
+    },
+
+    create(o: CreateOptions): CreateStateMachine {
+      return {
+        fiberId: o.fiberId,
+        definition: wireDef, // SAME reference as wireDefinition()/publishVersion()
+        initialData: o.initialData,
+        schemaRef: exactRef(spec.name, spec.version), // verified binding: name@version
+        ...(o.participants ? { participants: o.participants } : {}), // OMIT when absent
+        ...(o.parentFiberId ? { parentFiberId: o.parentFiberId } : {}), // OMIT when absent
+      };
+    },
+
+    upgradeFrom(o: UpgradeOptions): UpgradeFiber {
+      return {
+        fiberId: o.fiberId,
+        targetRef: exactRef(spec.name, spec.version),
+        newDefinition: wireDef, // SAME reference — re-pin hashes to the same logicHash
+        targetSequenceNumber: o.targetSequenceNumber,
+        ...(o.migration !== undefined ? { migration: o.migration } : {}), // OMIT (Option) when absent
+      };
+    },
+  };
+}

--- a/src/templates/migration.ts
+++ b/src/templates/migration.ts
@@ -1,0 +1,36 @@
+/**
+ * Migration builders — the `UpgradeFiber.migration` JSON-Logic transform applied on a version upgrade.
+ *
+ * THE FOOT-GUN (F9): a migration's evaluation root is the BARE prior state, not `state.x`.
+ * The chain evaluates the migration expression against `sm.stateData` directly
+ * (`MeteredEvaluator.eval(expr, sm.stateData, Migration)`, FiberEngine.scala:300), so:
+ *   - `{ var: '' }`            => the WHOLE prior state object
+ *   - `{ var: 'loyaltyPoints' }` => the top-level `loyaltyPoints` field
+ * This is UNLIKE an effect, where the root is the transition context and you read `{ var: 'state.x' }`.
+ * Writing `state.loyaltyPoints` in a migration silently reads `undefined`. These helpers hide that
+ * asymmetry by pinning the bare-state root for you.
+ *
+ * `migration` is `Option` on `UpgradeFiber` — when there is no transform, OMIT the key (never send `null`).
+ */
+
+/**
+ * Seed / overwrite top-level state fields on a version upgrade.
+ * Emits `{ merge: [{ var: '' }, fields] }` — merges `fields` onto the bare prior state, so existing
+ * fields are preserved and the named fields are added or overwritten.
+ *
+ * The `{ var: '' }` root is the BARE prior state (NOT `state.x` like an effect) — that asymmetry is
+ * exactly the F9 foot-gun this helper hides.
+ *
+ * @example seedFields({ loyaltyPoints: 0 }) // => { merge: [{ var: '' }, { loyaltyPoints: 0 }] }
+ */
+export const seedFields = (fields: Record<string, unknown>): unknown => ({
+  merge: [{ var: '' }, fields],
+});
+
+/**
+ * General migration transform with the bare-state root made explicit. `build` receives `{ var: '' }`
+ * (the whole prior state) and returns the migration JSON-Logic.
+ *
+ * @example migration((s) => ({ merge: [s, { x: 1 }] })) // => { merge: [{ var: '' }, { x: 1 }] }
+ */
+export const migration = (build: (priorState: { var: '' }) => unknown): unknown => build({ var: '' });

--- a/src/templates/state-shape.ts
+++ b/src/templates/state-shape.ts
@@ -1,0 +1,45 @@
+/**
+ * State-shape-with-defaults — the SDK half of Proposal 01's "declared state shape" (removes F5).
+ *
+ * A declared shape carries a `default` (and optional `type`) per field. It seeds `initialData` so every
+ * accumulator starts at a concrete value — a counter read via `{ '+': [{ var: 'state.x' }, ...] }` never
+ * resolves `null` because `x` was never written. It also yields the set of declared field names for
+ * Proposal 01's var-path checks.
+ */
+
+import type { SchemaFieldType } from '../schema/fiber-app.js';
+
+export interface StateShape {
+  fields: Record<string, { default: unknown; type?: SchemaFieldType }>;
+}
+
+/**
+ * Build `initialData` by overlaying `overrides` onto each field's declared `default`.
+ * Every declared field gets a concrete value, so no field reads `null` at runtime. An override for a
+ * field replaces that field's default; overrides for undeclared fields are ignored (only declared fields
+ * are emitted). Determinism: pure function of its inputs, stable key order (declared order).
+ *
+ * @example seedState({ fields: { purchaseCount: { default: 0 }, status: { default: 'ACTIVE' } } })
+ *          // => { purchaseCount: 0, status: 'ACTIVE' }
+ */
+export function seedState(
+  shape: StateShape,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  const seeded: Record<string, unknown> = {};
+  for (const [name, field] of Object.entries(shape.fields)) {
+    seeded[name] =
+      overrides !== undefined && Object.prototype.hasOwnProperty.call(overrides, name)
+        ? overrides[name]
+        : field.default;
+  }
+  return seeded;
+}
+
+/**
+ * The set of declared state-field names — the fields the effects may read.
+ * Feeds Proposal 01's var-path checks (a `{ var: 'state.foo' }` whose `foo` is not declared is suspect).
+ */
+export function declaredFields(shape: StateShape): Set<string> {
+  return new Set(Object.keys(shape.fields));
+}

--- a/tests/fixtures/riverdale-economy/README.md
+++ b/tests/fixtures/riverdale-economy/README.md
@@ -1,0 +1,11 @@
+# Vendored riverdale-economy goldens
+
+These JSON files are byte-for-byte copies of the chain-accepted definitions/policies from the
+`riverdale-economy` e2e green lane (origin: `ottochain` repo,
+`e2e-test/examples/riverdale-economy/`). They are the acceptance oracle for the
+`@ottochain/sdk/templates` builders: a template's output must deep-equal (and canonicalize
+byte-identically to) the form the chain already accepts on the green lane.
+
+Vendored here (rather than read from the sibling repo) so the SDK test suite is self-contained
+and runs in CI without the metagraph repo checked out. If a golden changes upstream, re-copy it
+and confirm the corresponding template still reproduces it.

--- a/tests/fixtures/riverdale-economy/capped-policy.json
+++ b/tests/fixtures/riverdale-economy/capped-policy.json
@@ -1,0 +1,14 @@
+{
+  "name": "capped.asset",
+  "version": "1.0.0",
+  "behavior": 28,
+  "supply": {
+    "maxSupply": 100,
+    "mintPolicy": { "==": [1, 1] }
+  },
+  "morphisms": {},
+  "stateShape": {
+    "typeName": "CappedState",
+    "fields": []
+  }
+}

--- a/tests/fixtures/riverdale-economy/consumer.definition.json
+++ b/tests/fixtures/riverdale-economy/consumer.definition.json
@@ -1,0 +1,174 @@
+{
+  "states": {
+    "ACTIVE": { "id": "ACTIVE", "isFinal": false },
+    "debt_current": { "id": "debt_current", "isFinal": false },
+    "marketplace_selling": { "id": "marketplace_selling", "isFinal": false }
+  },
+  "initialState": "ACTIVE",
+  "transitions": [
+    {
+      "from": "ACTIVE",
+      "to": "debt_current",
+      "eventName": "loan_funded",
+      "guard": { "==": [1, 1] },
+      "effect": {
+        "status": "debt_current",
+        "loanBalance": { "var": "event.amount" },
+        "balance": { "+": [{ "var": "state.balance" }, { "var": "event.amount" }] }
+      },
+      "dependencies": []
+    },
+    {
+      "from": "debt_current",
+      "to": "debt_current",
+      "eventName": "buy",
+      "guard": { "==": [1, 1] },
+      "effect": {
+        "_triggers": [
+          {
+            "targetMachineId": { "var": "event.retailerId" },
+            "eventName": "process_sale",
+            "payload": {
+              "buyerId": { "var": "machineId" },
+              "quantity": { "var": "event.quantity" },
+              "goodsAssetId": { "var": "event.goodsAssetId" }
+            }
+          }
+        ],
+        "_transferAsset": [
+          {
+            "assetId": { "var": "event.payAssetId" },
+            "recipient": { "var": "event.retailerId" }
+          }
+        ],
+        "status": "debt_current",
+        "purchaseCount": { "+": [{ "var": "state.purchaseCount" }, 1] }
+      },
+      "dependencies": []
+    },
+    {
+      "from": "debt_current",
+      "to": "debt_current",
+      "eventName": "make_payment",
+      "guard": { "==": [1, 1] },
+      "effect": {
+        "_triggers": [
+          {
+            "targetMachineId": { "var": "event.bankId" },
+            "eventName": "payment_received",
+            "payload": {
+              "borrowerId": { "var": "machineId" },
+              "amount": { "var": "event.amount" }
+            }
+          }
+        ],
+        "_transferAsset": [
+          {
+            "assetId": { "var": "event.repayAssetId" },
+            "recipient": { "var": "event.bankId" }
+          }
+        ],
+        "status": "debt_current",
+        "loanBalance": { "-": [{ "var": "state.loanBalance" }, { "var": "event.amount" }] },
+        "paymentsMade": { "+": [{ "var": "state.paymentsMade" }, 1] }
+      },
+      "dependencies": []
+    },
+    {
+      "from": "debt_current",
+      "to": "debt_current",
+      "eventName": "pay_taxes",
+      "guard": { "==": [1, 1] },
+      "effect": {
+        "_transferAsset": [
+          {
+            "assetId": { "var": "event.taxAssetId" },
+            "recipient": { "var": "event.govId" }
+          }
+        ],
+        "status": "debt_current",
+        "taxesPaid": { "+": [{ "var": "state.taxesPaid" }, { "var": "event.taxAmount" }] }
+      },
+      "dependencies": []
+    },
+    {
+      "from": "debt_current",
+      "to": "marketplace_selling",
+      "eventName": "list_item",
+      "guard": { "==": [1, 1] },
+      "effect": {
+        "_spawn": [
+          {
+            "childId": { "var": "event.auctionId" },
+            "definition": {
+              "states": {
+                "listed": { "id": "listed", "isFinal": false },
+                "bid_received": { "id": "bid_received", "isFinal": false },
+                "sold": { "id": "sold", "isFinal": true }
+              },
+              "initialState": "listed",
+              "transitions": [
+                {
+                  "from": "listed",
+                  "to": "bid_received",
+                  "eventName": "place_bid",
+                  "guard": { "==": [1, 1] },
+                  "effect": {
+                    "status": "bid_received",
+                    "highestBid": { "var": "event.bidAmount" },
+                    "highestBidder": { "var": "event.bidderId" }
+                  },
+                  "dependencies": []
+                },
+                {
+                  "from": "bid_received",
+                  "to": "sold",
+                  "eventName": "accept_bid",
+                  "guard": { "==": [1, 1] },
+                  "effect": {
+                    "_triggers": [
+                      {
+                        "targetMachineId": { "var": "parent.machineId" },
+                        "eventName": "sale_completed",
+                        "payload": {
+                          "amount": { "var": "state.highestBid" },
+                          "buyer": { "var": "state.highestBidder" }
+                        }
+                      }
+                    ],
+                    "status": "sold"
+                  },
+                  "dependencies": []
+                }
+              ]
+            },
+            "initialData": {
+              "reservePrice": { "var": "event.reservePrice" },
+              "itemName": { "var": "event.itemName" },
+              "sellerId": { "var": "machineId" },
+              "highestBid": 0,
+              "status": "listed"
+            },
+            "owners": { "var": "event.auctionOwners" }
+          }
+        ],
+        "status": "marketplace_selling",
+        "activeListings": { "+": [{ "var": "state.activeListings" }, 1] }
+      },
+      "dependencies": []
+    },
+    {
+      "from": "marketplace_selling",
+      "to": "debt_current",
+      "eventName": "sale_completed",
+      "guard": { "==": [1, 1] },
+      "effect": {
+        "status": "debt_current",
+        "balance": { "+": [{ "var": "state.balance" }, { "var": "event.amount" }] },
+        "activeListings": { "-": [{ "var": "state.activeListings" }, 1] },
+        "marketplaceSales": { "+": [{ "var": "state.marketplaceSales" }, 1] }
+      },
+      "dependencies": []
+    }
+  ]
+}

--- a/tests/fixtures/riverdale-economy/goods-policy.json
+++ b/tests/fixtures/riverdale-economy/goods-policy.json
@@ -1,0 +1,13 @@
+{
+  "name": "goods.asset",
+  "version": "1.0.0",
+  "behavior": 20,
+  "supply": {
+    "mintPolicy": { "==": [1, 1] }
+  },
+  "morphisms": {},
+  "stateShape": {
+    "typeName": "GoodsState",
+    "fields": []
+  }
+}

--- a/tests/fixtures/riverdale-economy/rvd-policy.json
+++ b/tests/fixtures/riverdale-economy/rvd-policy.json
@@ -1,0 +1,19 @@
+{
+  "name": "rvd.asset",
+  "version": "1.0.0",
+  "behavior": 28,
+  "supply": {
+    "mintPolicy": { "==": [1, 1] },
+    "burnPolicy": { "==": [1, 1] }
+  },
+  "morphisms": {
+    "TRANSFER": { "visibility": "PUBLIC" },
+    "FRACTIONALIZE": { "visibility": "PUBLIC" },
+    "BURN": { "visibility": "PUBLIC" },
+    "STAKE": { "visibility": "PUBLIC" }
+  },
+  "stateShape": {
+    "typeName": "RvdState",
+    "fields": []
+  }
+}

--- a/tests/schema/effects.test.ts
+++ b/tests/schema/effects.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  triggers,
+  spawn,
+  emit,
+  toFiber,
+  toWallet,
+  transferAsset,
+  RESERVED_EFFECT_KEYS,
+} from '../../src/schema/effects';
+
+// The acceptance oracle: the chain-accepted riverdale golden definition (green lane). Effects are FLAT
+// maps mixing `_`-directives with state-update fields; we deep-equal our builders against the exact
+// `_triggers` / `_spawn` fragments the chain re-derives. Loaded via fs (sibling repo, outside rootDir).
+const consumerDef = JSON.parse(
+  readFileSync(
+    resolve(
+      __dirname,
+      '../../../ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy/consumer.definition.json',
+    ),
+    'utf-8',
+  ),
+) as {
+  transitions: { eventName: string; effect: Record<string, unknown> }[];
+};
+
+const byEvent = (name: string) =>
+  consumerDef.transitions.find((t) => t.eventName === name) ??
+  (() => {
+    throw new Error(`no transition for ${name}`);
+  })();
+
+describe('schema/effects — reserved EFFECT directives match the riverdale green-lane canonical', () => {
+  it('triggers() projects {target,event,payload} → {targetMachineId,eventName,payload}, matching the `buy` transition', () => {
+    const buy = byEvent('buy'); // transition index 1
+    const built = triggers([
+      {
+        target: { var: 'event.retailerId' },
+        event: 'process_sale',
+        payload: {
+          buyerId: { var: 'machineId' },
+          quantity: { var: 'event.quantity' },
+          goodsAssetId: { var: 'event.goodsAssetId' },
+        },
+      },
+    ]);
+    expect(built).toEqual({ _triggers: [(buy.effect as { _triggers: unknown[] })._triggers[0]] });
+  });
+
+  it('triggers() defaults an omitted payload to {} (never null)', () => {
+    expect(triggers([{ target: 'm1', event: 'ping' }])).toEqual({
+      _triggers: [{ targetMachineId: 'm1', eventName: 'ping', payload: {} }],
+    });
+  });
+
+  it('spawn() wraps {childId,definition,initialData,owners} under _spawn, matching the `list_item` transition', () => {
+    const listItem = byEvent('list_item'); // transition index 4
+    const goldenSpawn = (listItem.effect as { _spawn: { definition: unknown }[] })._spawn;
+
+    const built = spawn([
+      {
+        // small leaf fields transcribed by hand (the real proof); the bulky child definition is the
+        // literal ProtoStateMachineDefinition the chain reads from the effect EXPRESSION.
+        childId: { var: 'event.auctionId' },
+        definition: goldenSpawn[0].definition as never,
+        initialData: {
+          reservePrice: { var: 'event.reservePrice' },
+          itemName: { var: 'event.itemName' },
+          sellerId: { var: 'machineId' },
+          highestBid: 0,
+          status: 'listed',
+        },
+        owners: { var: 'event.auctionOwners' },
+      },
+    ]);
+    expect(built).toEqual({ _spawn: goldenSpawn });
+  });
+
+  it('emit() passes events through under _emit and omits an absent destination', () => {
+    const built = emit([{ name: 'sale_completed', data: { var: 'state.highestBid' } }]);
+    expect(built).toEqual({ _emit: [{ name: 'sale_completed', data: { var: 'state.highestBid' } }] });
+    expect((built as { _emit: Record<string, unknown>[] })._emit[0]).not.toHaveProperty('destination');
+  });
+
+  it('emit() preserves an explicit destination', () => {
+    expect(emit([{ name: 'pinged', data: 1, destination: 'fiber-1' }])).toEqual({
+      _emit: [{ name: 'pinged', data: 1, destination: 'fiber-1' }],
+    });
+  });
+
+  it('RESERVED_EFFECT_KEYS lists all 7 reserved directive keys (Proposal 01 validator input)', () => {
+    expect(RESERVED_EFFECT_KEYS).toHaveLength(7);
+    for (const key of [
+      '_triggers',
+      '_spawn',
+      '_emit',
+      '_transferAsset',
+      '_scriptCall',
+      '_addDependency',
+      '_setDependencyActive',
+    ]) {
+      expect(RESERVED_EFFECT_KEYS).toContain(key);
+    }
+  });
+
+  it('toFiber / toWallet are identity labels (no wire effect, only intent)', () => {
+    const fiberId = { var: 'event.retailerId' };
+    const addr = '0xb0b';
+    expect(toFiber(fiberId)).toBe(fiberId);
+    expect(toWallet(addr)).toBe(addr);
+    // intent labels do not alter the directive's wire shape (composes with the real transferAsset)
+    expect(transferAsset([{ assetId: { var: 'a' }, recipient: toFiber(fiberId) }])).toEqual({
+      _transferAsset: [{ assetId: { var: 'a' }, recipient: fiberId }],
+    });
+  });
+
+  it('builders are pure — identical input yields identical output', () => {
+    const input = [{ target: 'm', event: 'e', payload: { x: 1 } }];
+    expect(triggers(input)).toEqual(triggers(input));
+    expect(emit([{ name: 'n', data: 1 }])).toEqual(emit([{ name: 'n', data: 1 }]));
+  });
+});

--- a/tests/schema/effects.test.ts
+++ b/tests/schema/effects.test.ts
@@ -13,13 +13,10 @@ import {
 
 // The acceptance oracle: the chain-accepted riverdale golden definition (green lane). Effects are FLAT
 // maps mixing `_`-directives with state-update fields; we deep-equal our builders against the exact
-// `_triggers` / `_spawn` fragments the chain re-derives. Loaded via fs (sibling repo, outside rootDir).
+// `_triggers` / `_spawn` fragments the chain re-derives. Vendored fixture (see fixtures README).
 const consumerDef = JSON.parse(
   readFileSync(
-    resolve(
-      __dirname,
-      '../../../ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy/consumer.definition.json',
-    ),
+    resolve(__dirname, '../fixtures/riverdale-economy/consumer.definition.json'),
     'utf-8',
   ),
 ) as {

--- a/tests/templates/asset-policy.test.ts
+++ b/tests/templates/asset-policy.test.ts
@@ -12,11 +12,8 @@ import {
 import { TOKEN_BEHAVIOR_BITS, type CreateAssetPolicy } from '../../src/ottochain/types';
 import { dropNulls } from '../../src/ottochain/drop-nulls';
 
-// The acceptance oracle: the chain-accepted riverdale golden policy JSONs.
-const GOLDEN_DIR = resolve(
-  __dirname,
-  '../../../ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy',
-);
+// The acceptance oracle: the chain-accepted riverdale golden policy JSONs (vendored, see fixtures README).
+const GOLDEN_DIR = resolve(__dirname, '../fixtures/riverdale-economy');
 const golden = (file: string): unknown => JSON.parse(readFileSync(resolve(GOLDEN_DIR, file), 'utf8'));
 
 describe('templates/asset-policy — behavior is summed from TOKEN_BEHAVIOR_BITS, never a literal', () => {

--- a/tests/templates/asset-policy.test.ts
+++ b/tests/templates/asset-policy.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  fungiblePolicy,
+  nftPolicy,
+  soulboundPolicy,
+  customPolicy,
+  sumBehavior,
+  defaultStateTypeName,
+} from '../../src/templates/asset-policy';
+import { TOKEN_BEHAVIOR_BITS, type CreateAssetPolicy } from '../../src/ottochain/types';
+import { dropNulls } from '../../src/ottochain/drop-nulls';
+
+// The acceptance oracle: the chain-accepted riverdale golden policy JSONs.
+const GOLDEN_DIR = resolve(
+  __dirname,
+  '../../../ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy',
+);
+const golden = (file: string): unknown => JSON.parse(readFileSync(resolve(GOLDEN_DIR, file), 'utf8'));
+
+describe('templates/asset-policy — behavior is summed from TOKEN_BEHAVIOR_BITS, never a literal', () => {
+  it('sumBehavior matches the documented presets (T=16,S=8,C=4,E=2,G=1)', () => {
+    expect(sumBehavior(['transferable', 'splittable', 'combinable'])).toBe(28); // fungible
+    expect(sumBehavior(['transferable'])).toBe(16); // plain NFT
+    expect(sumBehavior(['transferable', 'combinable'])).toBe(20); // goods-style NFT
+    expect(sumBehavior(['governable'])).toBe(1); // soulbound
+    expect(sumBehavior([])).toBe(0);
+    // the named bits really are the chain bit-weights
+    expect(TOKEN_BEHAVIOR_BITS).toEqual({
+      transferable: 16,
+      splittable: 8,
+      combinable: 4,
+      expirable: 2,
+      governable: 1,
+    });
+  });
+
+  it('defaultStateTypeName strips `.asset` and PascalCases + `State`', () => {
+    expect(defaultStateTypeName('rvd.asset')).toBe('RvdState');
+    expect(defaultStateTypeName('goods.asset')).toBe('GoodsState');
+    expect(defaultStateTypeName('capped.asset')).toBe('CappedState');
+    expect(defaultStateTypeName('my-currency.asset')).toBe('MyCurrencyState');
+  });
+});
+
+describe('templates/asset-policy — reproduces the riverdale goldens exactly (deep-equal)', () => {
+  it('fungiblePolicy reproduces rvd-policy.json (behavior 28, mint+burn, full morphism set)', () => {
+    const out = fungiblePolicy({
+      name: 'rvd.asset',
+      version: '1.0.0',
+      mintable: true,
+      burnable: true,
+    });
+    expect(out).toEqual(golden('rvd-policy.json'));
+  });
+
+  it('nftPolicy reproduces goods-policy.json (behavior 20, morphisms {}, mint only)', () => {
+    const out = nftPolicy({
+      name: 'goods.asset',
+      version: '1.0.0',
+      combinable: true,
+    });
+    expect(out).toEqual(golden('goods-policy.json'));
+  });
+
+  it('customPolicy reproduces capped-policy.json (behavior 28, maxSupply 100, morphisms {})', () => {
+    const out = customPolicy({
+      name: 'capped.asset',
+      version: '1.0.0',
+      behavior: ['transferable', 'splittable', 'combinable'],
+      supply: { maxSupply: 100, mintPolicy: { '==': [1, 1] } },
+      morphisms: {},
+    });
+    expect(out).toEqual(golden('capped-policy.json'));
+  });
+});
+
+describe('templates/asset-policy — wire invariants (no null, required fields present)', () => {
+  const all: CreateAssetPolicy[] = [
+    fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true }),
+    nftPolicy({ name: 'goods.asset', version: '1.0.0', combinable: true }),
+    soulboundPolicy({ name: 'badge.asset', version: '1.0.0' }),
+    customPolicy({
+      name: 'capped.asset',
+      version: '1.0.0',
+      behavior: ['transferable', 'splittable', 'combinable'],
+      supply: { maxSupply: 100, mintPolicy: { '==': [1, 1] } },
+      morphisms: {},
+    }),
+  ];
+
+  it('every preset emits the required `supply` and `morphisms` (never omitted)', () => {
+    for (const p of all) {
+      expect(p).toHaveProperty('supply');
+      expect(p).toHaveProperty('morphisms');
+      expect(p.morphisms).toBeDefined();
+      expect(p.supply).toBeDefined();
+    }
+  });
+
+  it('no preset emits a null anywhere (dropNulls is a no-op ⇒ JCS-stable)', () => {
+    for (const p of all) {
+      expect(dropNulls(p as unknown as Record<string, unknown>)).toEqual(p);
+      expect(JSON.stringify(p)).not.toContain('null');
+    }
+  });
+
+  it('absent optionals are OMITTED, not emitted as undefined keys', () => {
+    // an uncapped, non-mintable, non-burnable fungible has an EMPTY supply object
+    const minimal = fungiblePolicy({ name: 'plain.asset', version: '0.0.1', stakeable: false });
+    expect(minimal.supply).toEqual({}); // no maxSupply/mintPolicy/burnPolicy/decimals keys
+    expect(Object.keys(minimal.supply)).toHaveLength(0);
+    expect(minimal).not.toHaveProperty('metadata');
+    // morphisms: only TRANSFER + FRACTIONALIZE (stakeable:false, not burnable)
+    expect(Object.keys(minimal.morphisms).sort()).toEqual(['FRACTIONALIZE', 'TRANSFER']);
+  });
+});
+
+describe('templates/asset-policy — preset shapes & options', () => {
+  it('fungiblePolicy: mintGuard overrides the default mint guard', () => {
+    const guard = { '>': [{ var: 'witness.proof' }, 0] };
+    const out = fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintGuard: guard });
+    expect(out.supply.mintPolicy).toEqual(guard);
+    expect(out.behavior).toBe(28);
+  });
+
+  it('fungiblePolicy: decimals + maxSupply flow into supply', () => {
+    const out = fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', decimals: 6, maxSupply: 1000 });
+    expect(out.supply).toEqual({ maxSupply: 1000, decimals: 6 });
+  });
+
+  it('nftPolicy: plain NFT is behavior 16 with mint-only supply', () => {
+    const out = nftPolicy({ name: 'art.asset', version: '1.0.0' });
+    expect(out.behavior).toBe(16);
+    expect(out.morphisms).toEqual({});
+    expect(out.supply).toEqual({ mintPolicy: { '==': [1, 1] } });
+    expect(out.stateShape).toEqual({ typeName: 'ArtState', fields: [] });
+  });
+
+  it('nftPolicy: transferable:false drops the T bit (bound collectible)', () => {
+    expect(nftPolicy({ name: 'bound.asset', version: '1.0.0', transferable: false }).behavior).toBe(0);
+    expect(
+      nftPolicy({ name: 'bound.asset', version: '1.0.0', transferable: false, combinable: true }).behavior,
+    ).toBe(4);
+  });
+
+  it('soulboundPolicy: G=1, no TRANSFER morphism, empty supply (mint closed)', () => {
+    const out = soulboundPolicy({ name: 'badge.asset', version: '1.0.0' });
+    expect(out.behavior).toBe(1);
+    expect(out.morphisms).toEqual({});
+    expect(out.supply).toEqual({});
+    expect(out.stateShape).toEqual({ typeName: 'BadgeState', fields: [] });
+    expect(soulboundPolicy({ name: 'badge.asset', version: '1.0.0', expirable: true }).behavior).toBe(3);
+  });
+
+  it('customPolicy: stateTypeName override + metadata pass through', () => {
+    const out = customPolicy({
+      name: 'thing.asset',
+      version: '2.0.0',
+      behavior: ['transferable', 'governable'],
+      supply: {},
+      morphisms: { TRANSFER: { visibility: 'GOVERNED' } },
+      stateTypeName: 'CustomThing',
+      metadata: { team: 'core' },
+    });
+    expect(out.behavior).toBe(17);
+    expect(out.stateShape.typeName).toBe('CustomThing');
+    expect(out.metadata).toEqual({ team: 'core' });
+    expect(out.morphisms).toEqual({ TRANSFER: { visibility: 'GOVERNED' } });
+  });
+});
+
+describe('templates/asset-policy — pure & deterministic (same input ⇒ identical output)', () => {
+  it('repeated calls deep-equal and do not share mutable sub-objects', () => {
+    const a = fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true });
+    const b = fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true });
+    expect(a).toEqual(b);
+    // mutating one output must not affect a fresh call (no shared references)
+    a.morphisms.TRANSFER.visibility = 'DISABLED';
+    expect(
+      fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true }).morphisms
+        .TRANSFER.visibility,
+    ).toBe('PUBLIC');
+  });
+});

--- a/tests/templates/canonical-round-trip.test.ts
+++ b/tests/templates/canonical-round-trip.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Golden canonical round-trip — the load-bearing guard (handoff §5 step 6, CLAUDE.md rule #1).
+ *
+ * The chain signs/verifies every update over `JCS(dropNulls(payload))`. A template that shifts that
+ * canonical by one byte breaks the create/publish signature with an opaque `InvalidSignature` (HTTP 400).
+ *
+ * Proof technique (mirrors the repo's `tests/signing.test.ts` signing-parity convention): ECDSA signing
+ * here is deterministic (RFC 6979), so two payloads produce the SAME signature under ONE key IFF their
+ * `JCS(dropNulls(.))` bytes are byte-identical. We therefore sign each builder output and its checked-in
+ * green-lane golden with the same key and assert equal signatures — i.e. the template emits the EXACT
+ * canonical the chain already accepts in the green lane. Reuses the real SDK signing path
+ * (`signDataUpdate`, which applies `dropNulls` then RFC-8785 canonicalizes), not a re-derived JCS.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { generateKeyPair } from '@constellation-network/metagraph-sdk';
+import { signDataUpdate } from '../../src/signing';
+import { dropNulls } from '../../src/ottochain/drop-nulls';
+import { fungiblePolicy, nftPolicy, customPolicy } from '../../src/templates/asset-policy';
+import { machine, transition, effect } from '../../src/templates/machine';
+import { defineFiberApp } from '../../src/schema/fiber-app';
+import type { MachineShape } from '../../src/ottochain/types';
+
+const GOLDEN_DIR = resolve(
+  __dirname,
+  '../../../ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy',
+);
+const golden = (file: string): unknown => JSON.parse(readFileSync(resolve(GOLDEN_DIR, file), 'utf8'));
+
+// One fresh key; deterministic signatures ⇒ equal signature == byte-identical signed canonical.
+const key = generateKeyPair().privateKey;
+const signsIdentically = (a: unknown, b: unknown): void =>
+  expect(signDataUpdate(a, key).signature).toBe(signDataUpdate(b, key).signature);
+
+describe('templates — golden canonical round-trip (signed JCS(dropNulls) == green-lane fixture)', () => {
+  it('fungiblePolicy → byte-identical canonical to rvd-policy.json', () => {
+    signsIdentically(
+      fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true }),
+      golden('rvd-policy.json'),
+    );
+  });
+
+  it('nftPolicy → byte-identical canonical to goods-policy.json', () => {
+    signsIdentically(nftPolicy({ name: 'goods.asset', version: '1.0.0', combinable: true }), golden('goods-policy.json'));
+  });
+
+  it('customPolicy → byte-identical canonical to capped-policy.json', () => {
+    signsIdentically(
+      customPolicy({
+        name: 'capped.asset',
+        version: '1.0.0',
+        behavior: ['transferable', 'splittable', 'combinable'],
+        supply: { maxSupply: 100, mintPolicy: { '==': [1, 1] } },
+        morphisms: {},
+      }),
+      golden('capped-policy.json'),
+    );
+  });
+
+  it('policy output carries NO null leaf — dropNulls is a no-op, so the canonical is stable', () => {
+    const policy = fungiblePolicy({ name: 'rvd.asset', version: '1.0.0', mintable: true, burnable: true });
+    expect(dropNulls(policy)).toEqual(policy);
+    expect(JSON.stringify(policy)).not.toContain('null');
+  });
+
+  it('machine() publish + create definitions sign identically (verified binding at the byte level)', () => {
+    const schemaShape: MachineShape = { stateMessage: { typeName: 'MState', fields: [] }, commands: {} };
+    const app = defineFiberApp({
+      metadata: { name: 'M', app: 'riverdale', type: 'm', version: '1.0.0' },
+      states: { A: { id: 'A', isFinal: false }, B: { id: 'B', isFinal: false } },
+      initialState: 'A',
+      transitions: [transition({ from: 'A', to: 'B', on: 'go', effect: effect({ status: 'B' }) })],
+    });
+    const m = machine({ name: 'm.package', version: '1.0.0', app, schemaShape });
+    signsIdentically(m.publishVersion().definition, m.create({ fiberId: 'f', initialData: {} }).definition);
+  });
+});

--- a/tests/templates/canonical-round-trip.test.ts
+++ b/tests/templates/canonical-round-trip.test.ts
@@ -22,10 +22,7 @@ import { machine, transition, effect } from '../../src/templates/machine';
 import { defineFiberApp } from '../../src/schema/fiber-app';
 import type { MachineShape } from '../../src/ottochain/types';
 
-const GOLDEN_DIR = resolve(
-  __dirname,
-  '../../../ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy',
-);
+const GOLDEN_DIR = resolve(__dirname, '../fixtures/riverdale-economy');
 const golden = (file: string): unknown => JSON.parse(readFileSync(resolve(GOLDEN_DIR, file), 'utf8'));
 
 // One fresh key; deterministic signatures ⇒ equal signature == byte-identical signed canonical.

--- a/tests/templates/machine.test.ts
+++ b/tests/templates/machine.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { transition, effect, machine } from '../../src/templates/machine';
+import { defineFiberApp } from '../../src/schema/fiber-app';
+import { transferAsset } from '../../src/schema/effects';
+import type { MachineShape } from '../../src/ottochain/types';
+
+// The riverdale golden — the chain-accepted form `transition()`/`effect()` must reproduce byte-for-byte
+// (key order is irrelevant; JCS sorts keys, so deep equality is the right oracle).
+const CONSUMER_DEF = JSON.parse(
+  readFileSync(
+    '/home/euler/repos/ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy/consumer.definition.json',
+    'utf8',
+  ),
+) as { transitions: Record<string, unknown>[] };
+
+describe('templates/machine — effect()', () => {
+  it('merges the state-update + directive fragments into ONE flat map', () => {
+    expect(effect({ a: 1 }, { _x: 2 })).toEqual({ a: 1, _x: 2 });
+  });
+
+  it('with no directives is just the state update', () => {
+    expect(effect({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('is NOT merge-wrapped (flat map, no `merge` key)', () => {
+    expect(effect({ status: 'X' }, { _triggers: [] })).not.toHaveProperty('merge');
+  });
+
+  it('later directives override earlier keys (Object.assign semantics)', () => {
+    expect(effect({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+});
+
+describe('templates/machine — transition()', () => {
+  it('maps `on` -> `eventName`, defaults guard to {"==":[1,1]} and dependencies to []', () => {
+    const t = transition({ from: 'A', to: 'B', on: 'go' });
+    expect(t.eventName).toBe('go');
+    expect(t.guard).toEqual({ '==': [1, 1] });
+    expect(t.dependencies).toEqual([]);
+  });
+
+  it('passes guard / effect / dependencies through', () => {
+    const eff = effect({ status: 'X' });
+    expect(
+      transition({ from: 'A', to: 'B', on: 'go', guard: { '!': [false] }, effect: eff, dependencies: ['uuid-1'] }),
+    ).toEqual({
+      from: 'A',
+      to: 'B',
+      eventName: 'go',
+      guard: { '!': [false] },
+      effect: { status: 'X' },
+      dependencies: ['uuid-1'],
+    });
+  });
+
+  it('deep-equals the riverdale `buy` transition (golden index 1)', () => {
+    const buyTriggers = {
+      _triggers: [
+        {
+          targetMachineId: { var: 'event.retailerId' },
+          eventName: 'process_sale',
+          payload: {
+            buyerId: { var: 'machineId' },
+            quantity: { var: 'event.quantity' },
+            goodsAssetId: { var: 'event.goodsAssetId' },
+          },
+        },
+      ],
+    };
+
+    const built = transition({
+      from: 'debt_current',
+      to: 'debt_current',
+      on: 'buy',
+      guard: { '==': [1, 1] },
+      effect: effect(
+        { status: 'debt_current', purchaseCount: { '+': [{ var: 'state.purchaseCount' }, 1] } },
+        buyTriggers,
+        { _transferAsset: [{ assetId: { var: 'event.payAssetId' }, recipient: { var: 'event.retailerId' } }] },
+      ),
+      dependencies: [],
+    });
+
+    expect(built).toEqual(CONSUMER_DEF.transitions[1]);
+  });
+
+  it('composes the same `buy` transition using the existing transferAsset() builder', () => {
+    const built = transition({
+      from: 'debt_current',
+      to: 'debt_current',
+      on: 'buy',
+      effect: effect(
+        { status: 'debt_current', purchaseCount: { '+': [{ var: 'state.purchaseCount' }, 1] } },
+        {
+          _triggers: [
+            {
+              targetMachineId: { var: 'event.retailerId' },
+              eventName: 'process_sale',
+              payload: {
+                buyerId: { var: 'machineId' },
+                quantity: { var: 'event.quantity' },
+                goodsAssetId: { var: 'event.goodsAssetId' },
+              },
+            },
+          ],
+        },
+        transferAsset([{ assetId: { var: 'event.payAssetId' }, recipient: { var: 'event.retailerId' } }]),
+      ),
+    });
+
+    expect(built).toEqual(CONSUMER_DEF.transitions[1]);
+  });
+});
+
+describe('templates/machine — machine() verified binding', () => {
+  const schemaShape: MachineShape = {
+    stateMessage: { typeName: 'ConsumerState', fields: [] },
+    commands: {},
+  };
+
+  const app = defineFiberApp({
+    metadata: { name: 'Consumer', app: 'riverdale', type: 'consumer', version: '1.0.0' },
+    states: {
+      ACTIVE: { id: 'ACTIVE', isFinal: false },
+      debt_current: { id: 'debt_current', isFinal: false },
+    },
+    initialState: 'ACTIVE',
+    transitions: [
+      transition({
+        from: 'ACTIVE',
+        to: 'debt_current',
+        on: 'loan_funded',
+        effect: effect({ status: 'debt_current', loanBalance: { var: 'event.amount' } }),
+      }),
+    ],
+  });
+
+  const m = machine({ name: 'consumer.package', version: '1.0.0', app, schemaShape });
+
+  it('publish, create, upgrade, and wireDefinition share ONE definition object (===)', () => {
+    expect(m.publishVersion().definition).toBe(m.wireDefinition());
+    expect(m.create({ fiberId: 'fid', initialData: {} }).definition).toBe(m.wireDefinition());
+    expect(m.upgradeFrom({ fiberId: 'fid', targetSequenceNumber: 1 }).newDefinition).toBe(m.wireDefinition());
+  });
+
+  it('publishVersion().definition toEqual create().definition toEqual wireDefinition()', () => {
+    const pub = m.publishVersion();
+    const cre = m.create({ fiberId: 'fid', initialData: {} });
+    expect(pub.definition).toEqual(cre.definition);
+    expect(cre.definition).toEqual(m.wireDefinition());
+  });
+
+  it('publishVersion conforms to PublishMachineVersion (name/version/machineShape/strict + schemaB64)', () => {
+    const pub = m.publishVersion();
+    expect(pub.name).toBe('consumer.package');
+    expect(pub.version).toBe('1.0.0');
+    expect(pub.machineShape).toBe(schemaShape);
+    expect(pub.strict).toBe(false); // REQUIRED, defaults to false
+    expect(pub.schemaB64).toBe(''); // REQUIRED, defaults to empty base64
+    expect(pub).not.toHaveProperty('metadata'); // OMITTED when absent
+  });
+
+  it('publishVersion respects strict / metadata / schemaB64 options', () => {
+    const pub = m.publishVersion({ strict: true, metadata: { docs: 'https://x' }, schemaB64: 'AAAA' });
+    expect(pub.strict).toBe(true);
+    expect(pub.metadata).toEqual({ docs: 'https://x' });
+    expect(pub.schemaB64).toBe('AAAA');
+  });
+
+  it('create references name@version via schemaRef and OMITS absent optionals', () => {
+    const cre = m.create({ fiberId: 'fid', initialData: { purchaseCount: 0 } });
+    expect(cre.schemaRef).toEqual({ name: 'consumer.package', version: { Exact: { version: '1.0.0' } } });
+    expect(cre.fiberId).toBe('fid');
+    expect(cre.initialData).toEqual({ purchaseCount: 0 });
+    expect(cre).not.toHaveProperty('participants');
+    expect(cre).not.toHaveProperty('parentFiberId');
+  });
+
+  it('create includes participants / parentFiberId when provided', () => {
+    const cre = m.create({
+      fiberId: 'fid',
+      initialData: {},
+      participants: ['0xabc'],
+      parentFiberId: 'parent-id',
+    });
+    expect(cre.participants).toEqual(['0xabc']);
+    expect(cre.parentFiberId).toBe('parent-id');
+  });
+
+  it('upgradeFrom OMITS migration when absent, INCLUDES it (never null) when present', () => {
+    const up1 = m.upgradeFrom({ fiberId: 'fid', targetSequenceNumber: 3 });
+    expect(up1).not.toHaveProperty('migration');
+    expect(up1.targetRef).toEqual({ name: 'consumer.package', version: { Exact: { version: '1.0.0' } } });
+    expect(up1.targetSequenceNumber).toBe(3);
+
+    const up2 = m.upgradeFrom({
+      fiberId: 'fid',
+      targetSequenceNumber: 3,
+      migration: { merge: [{ var: '' }, { loyaltyPoints: 0 }] },
+    });
+    expect(up2.migration).toEqual({ merge: [{ var: '' }, { loyaltyPoints: 0 }] });
+  });
+
+  it('is pure/deterministic: same machine emits identical bodies across calls', () => {
+    expect(m.publishVersion()).toEqual(m.publishVersion());
+    expect(m.create({ fiberId: 'fid', initialData: {} })).toEqual(
+      m.create({ fiberId: 'fid', initialData: {} }),
+    );
+  });
+});

--- a/tests/templates/machine.test.ts
+++ b/tests/templates/machine.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { transition, effect, machine } from '../../src/templates/machine';
 import { defineFiberApp } from '../../src/schema/fiber-app';
 import { transferAsset } from '../../src/schema/effects';
 import type { MachineShape } from '../../src/ottochain/types';
 
 // The riverdale golden — the chain-accepted form `transition()`/`effect()` must reproduce byte-for-byte
-// (key order is irrelevant; JCS sorts keys, so deep equality is the right oracle).
+// (key order is irrelevant; JCS sorts keys, so deep equality is the right oracle). Vendored fixture.
 const CONSUMER_DEF = JSON.parse(
   readFileSync(
-    '/home/euler/repos/ottochain-riverdale-e2e/e2e-test/examples/riverdale-economy/consumer.definition.json',
+    resolve(__dirname, '../fixtures/riverdale-economy/consumer.definition.json'),
     'utf8',
   ),
 ) as { transitions: Record<string, unknown>[] };

--- a/tests/templates/migration.test.ts
+++ b/tests/templates/migration.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from '@jest/globals';
+import { seedFields, migration } from '../../src/templates/migration';
+
+// The acceptance oracle: the chain-accepted golden migration from the riverdale green lane.
+// retailer-migration.json === { merge: [{ var: '' }, { loyaltyPoints: 0 }] }
+const retailerMigrationGolden = { merge: [{ var: '' }, { loyaltyPoints: 0 }] };
+
+describe('templates/migration — bare-state-root transforms (F9)', () => {
+  it('seedFields emits {merge:[{var:""},fields]} — byte-equal to retailer-migration.json', () => {
+    expect(seedFields({ loyaltyPoints: 0 })).toEqual(retailerMigrationGolden);
+  });
+
+  it('seedFields pins the BARE-state root {var:""}, not state.x like an effect', () => {
+    const m = seedFields({ loyaltyPoints: 0 }) as { merge: [{ var: string }, unknown] };
+    expect(m.merge[0]).toEqual({ var: '' });
+    // the field key is read top-level — no `state.` prefix leaks into the migration
+    expect(JSON.stringify(m)).not.toContain('state.');
+  });
+
+  it('seedFields carries multiple fields and arbitrary value types', () => {
+    expect(seedFields({ loyaltyPoints: 0, tier: 'gold', active: true })).toEqual({
+      merge: [{ var: '' }, { loyaltyPoints: 0, tier: 'gold', active: true }],
+    });
+  });
+
+  it('seedFields is pure/deterministic — same input, identical output across calls', () => {
+    expect(seedFields({ loyaltyPoints: 0 })).toEqual(seedFields({ loyaltyPoints: 0 }));
+  });
+
+  it('migration exposes the bare-state root and builds a general transform', () => {
+    expect(migration((s) => ({ merge: [s, { x: 1 }] }))).toEqual({ merge: [{ var: '' }, { x: 1 }] });
+  });
+
+  it('migration passes {var:""} into the builder so a field reads top-level', () => {
+    expect(migration((s) => s)).toEqual({ var: '' });
+    expect(migration((s) => ({ cat: [s, '-suffix'] }))).toEqual({ cat: [{ var: '' }, '-suffix'] });
+  });
+});

--- a/tests/templates/state-shape.test.ts
+++ b/tests/templates/state-shape.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from '@jest/globals';
+import { seedState, declaredFields, type StateShape } from '../../src/templates/state-shape';
+
+// The acceptance oracle: the chain-accepted seeded accumulators from the riverdale green lane.
+// consumer.initial.json
+const consumerInitialGolden = {
+  balance: 100000,
+  loanBalance: 0,
+  purchaseCount: 0,
+  paymentsMade: 0,
+  activeListings: 0,
+  marketplaceSales: 0,
+  taxesPaid: 0,
+  status: 'ACTIVE',
+};
+
+// A StateShape whose defaults are exactly the golden seeded values.
+const consumerShape: StateShape = {
+  fields: {
+    balance: { default: 100000, type: 'integer' },
+    loanBalance: { default: 0, type: 'integer' },
+    purchaseCount: { default: 0, type: 'integer' },
+    paymentsMade: { default: 0, type: 'integer' },
+    activeListings: { default: 0, type: 'integer' },
+    marketplaceSales: { default: 0, type: 'integer' },
+    taxesPaid: { default: 0, type: 'integer' },
+    status: { default: 'ACTIVE', type: 'string' },
+  },
+};
+
+describe('templates/state-shape — declared defaults seed initialData (F5)', () => {
+  it('seedState reproduces consumer.initial.json from the declared defaults', () => {
+    expect(seedState(consumerShape)).toEqual(consumerInitialGolden);
+  });
+
+  it('seedState overlays overrides onto the defaults (override wins)', () => {
+    expect(seedState(consumerShape, { balance: 250, status: 'debt_current' })).toEqual({
+      ...consumerInitialGolden,
+      balance: 250,
+      status: 'debt_current',
+    });
+  });
+
+  it('seedState emits a concrete value for every declared field — never null/undefined', () => {
+    const seeded = seedState(consumerShape);
+    for (const v of Object.values(seeded)) {
+      expect(v).not.toBeNull();
+      expect(v).not.toBeUndefined();
+    }
+  });
+
+  it('seedState ignores overrides for undeclared fields (only declared fields emitted)', () => {
+    const seeded = seedState(consumerShape, { notAField: 'nope' });
+    expect(seeded).toEqual(consumerInitialGolden);
+    expect(seeded).not.toHaveProperty('notAField');
+  });
+
+  it('seedState is pure/deterministic — same inputs, identical output across calls', () => {
+    expect(seedState(consumerShape, { balance: 7 })).toEqual(seedState(consumerShape, { balance: 7 }));
+  });
+
+  it('declaredFields returns the 8 declared consumer field names', () => {
+    expect(declaredFields(consumerShape)).toEqual(
+      new Set([
+        'balance',
+        'loanBalance',
+        'purchaseCount',
+        'paymentsMade',
+        'activeListings',
+        'marketplaceSales',
+        'taxesPaid',
+        'status',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Implements **Phase A** of the fiber-ergonomics program's SDK handoff (`docs/proposals/fiber-ergonomics/00-sdk-stdlib-and-templates.md`, in the metagraph repo) — a typed template/builder layer so app authors stop hand-rolling deeply-nested JSON-Logic. Off-chain, additive, **no chain change**; the raw-JSON path keeps working.

## What's added (`@ottochain/sdk/templates`)
- **`src/templates/asset-policy.ts`** — `fungiblePolicy` / `nftPolicy` / `soulboundPolicy` / `customPolicy`. Behavior bits are **summed from `TOKEN_BEHAVIOR_BITS`** (T=16/S=8/C=4/E=2/G=1), never a magic literal. `morphisms` is always present (required on the wire; NFT emits `{}`).
- **`src/schema/effects.ts`** (extended) — adds `triggers` / `spawn` / `emit` (completing the directive set alongside the existing `transferAsset`/`addDependency`/`setDependencyActive`), plus `toFiber`/`toWallet` intent helpers and a `RESERVED_EFFECT_KEYS` export mirrored verbatim from the chain's `ReservedKeys`.
- **`src/templates/machine.ts`** — `transition()`/`effect()` composition + the `machine()` skeleton that **owns one definition** and emits `publishVersion()`/`create()`/`upgradeFrom()`/`wireDefinition()` so publish and create are byte-identical (verified-binding by construction). Reuses `toProtoDefinition` — one canonicalization path.
- **`src/templates/migration.ts`** (`seedFields`/`migration`, hiding the bare-`{"var":""}`-root foot-gun) and **`src/templates/state-shape.ts`** (`seedState`/`declaredFields`, auto-seeding accumulators so reads never hit `null`).
- Envelope helpers `createPublishMachineVersionPayload` + `createUpgradeFiberPayload`; `./templates` subpath wired into `package.json` exports.

## Why it's canonical-safe (CLAUDE.md rule #1)
The chain signs/verifies over `JCS(dropNulls(payload))`. Builders omit absent optionals (never emit `null`) and always send required-no-default fields (`strict` on publish, `morphisms` on policy, `dependencies: []` per transition), reusing the existing projectors rather than re-deriving the wire shape.

## Tests (56 new, full suite green)
- **Snapshot deep-equal** against the chain-accepted riverdale green-lane goldens: `fungiblePolicy` ⇒ `rvd-policy.json` (behavior 28), `nftPolicy` ⇒ `goods-policy.json` (20), `customPolicy` ⇒ `capped-policy.json`; `triggers`/`spawn` ⇒ the `consumer.definition.json` fragments; `seedFields`/`seedState` ⇒ `retailer-migration.json`/`consumer.initial.json`.
- **Verified-binding**: `machine().publishVersion().definition` deep-equals `machine().create().definition`.
- **Golden canonical round-trip** (the load-bearing guard): signs each builder output and its green-lane golden under one deterministic key and asserts equal signatures — proving byte-identical `JCS(dropNulls(.))`. Reuses the real `signDataUpdate` path.
- Goldens are **vendored** under `tests/fixtures/riverdale-economy/` (with a provenance README) so the suite is self-contained in CI.

`npm run build` green (cjs/esm/types); `Test Suites: 15 passed, Tests: 225 passed` — no regressions.

## Deferred (out of scope, by design)
**Phase B — genesis std-lib** (chain-touching `std.*` asset-policy packages): waits for these template shapes to settle, and needs the chain-side `GenesisBuilder`/`ManifestPackage` asset-policy arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)